### PR TITLE
Replace hashing algo, fix example scripts import

### DIFF
--- a/examples/create_coco_project_single_task.py
+++ b/examples/create_coco_project_single_task.py
@@ -2,7 +2,7 @@ from dotenv import dotenv_values
 
 from geti_sdk import Geti
 from geti_sdk.annotation_readers import DatumAnnotationReader
-from geti_sdk.demo_tools import get_coco_dataset
+from geti_sdk.demos import get_coco_dataset
 
 if __name__ == "__main__":
     # Get credentials from .env file

--- a/examples/create_coco_project_task_chain.py
+++ b/examples/create_coco_project_task_chain.py
@@ -2,7 +2,7 @@ from dotenv import dotenv_values
 
 from geti_sdk import Geti
 from geti_sdk.annotation_readers import DatumAnnotationReader
-from geti_sdk.demo_tools import get_coco_dataset
+from geti_sdk.demos import get_coco_dataset
 from geti_sdk.utils import get_task_types_by_project_type
 
 if __name__ == "__main__":

--- a/examples/create_demo_projects.py
+++ b/examples/create_demo_projects.py
@@ -1,7 +1,7 @@
 from dotenv import dotenv_values
 
 from geti_sdk import Geti
-from geti_sdk.demo_tools import (
+from geti_sdk.demos import (
     create_anomaly_classification_demo_project,
     create_classification_demo_project,
     create_detection_demo_project,

--- a/examples/upload_and_predict_from_numpy.py
+++ b/examples/upload_and_predict_from_numpy.py
@@ -5,7 +5,7 @@ import numpy as np
 from dotenv import dotenv_values
 
 from geti_sdk import Geti
-from geti_sdk.demo_tools import NOTEBOOK_DATA_PATH, ensure_trained_example_project
+from geti_sdk.demos import NOTEBOOK_DATA_PATH, ensure_trained_example_project
 
 
 def rotate_image(image: np.ndarray, angle: float) -> np.ndarray:

--- a/examples/upload_and_predict_media_from_folder.py
+++ b/examples/upload_and_predict_media_from_folder.py
@@ -1,7 +1,7 @@
 from dotenv import dotenv_values
 
 from geti_sdk import Geti
-from geti_sdk.demo_tools import NOTEBOOK_DATA_PATH, ensure_trained_example_project
+from geti_sdk.demos import NOTEBOOK_DATA_PATH, ensure_trained_example_project
 
 if __name__ == "__main__":
     # Get credentials from .env file

--- a/geti_sdk/demos/data_helpers/anomaly_helpers.py
+++ b/geti_sdk/demos/data_helpers/anomaly_helpers.py
@@ -100,7 +100,10 @@ def get_mvtec_dataset_from_path(dataset_path: str = "data") -> str:
     url = f"https://www.mydrive.ch/shares/38536/3830184030e49fe74747669442f0f282/download/420938166-1629953277/{archive_name}"
     download_file(url, target_folder=dataset_path, check_valid_archive=False)
     archive_path = os.path.join(dataset_path, archive_name)
-    validate_hash(archive_path, "4fe2681f0ce1793cbf71d762f926d564")
+    validate_hash(
+        file_path=archive_path,
+        expected_hash="146b2166c35a1d0cf37ded091366ac01a50338b4ac704632f1239890eaca4449",
+    )
 
     logging.info(f"Extracting the '{dataset_name}' dataset at path {archive_path}...")
     with tarfile.open(archive_path) as tar_file:

--- a/geti_sdk/demos/data_helpers/download_helpers.py
+++ b/geti_sdk/demos/data_helpers/download_helpers.py
@@ -119,7 +119,7 @@ def validate_hash(file_path: str, expected_hash: str) -> None:
     :param expected_hash: Expected hash of the file.
     """
     with open(file_path, "rb") as hash_file:
-        downloaded_hash = hashlib.md5(hash_file.read()).hexdigest()
+        downloaded_hash = hashlib.sha256(hash_file.read()).hexdigest()
     if downloaded_hash != expected_hash:
         raise ValueError(
             f"Downloaded file {file_path} does not match the required hash."


### PR DESCRIPTION
This PR replaces the md5 hashing algorithm with the sha256, and adds hash validation for the coco dataset downloader (hashes are added for the val2017 dataset only, which is the default subset used in the SDK examples)