### PR TITLE
Update sc_annotation_reader

### DIFF
--- a/geti_sdk/annotation_readers/__init__.py
+++ b/geti_sdk/annotation_readers/__init__.py
@@ -31,7 +31,7 @@ Module contents
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: geti_sdk.annotation_readers.sc_annotation_reader
+.. automodule:: geti_sdk.annotation_readers.geti_annotation_reader
    :members:
    :undoc-members:
    :show-inheritance:
@@ -50,11 +50,11 @@ Module contents
 from .base_annotation_reader import AnnotationReader
 from .datumaro_annotation_reader import DatumAnnotationReader
 from .directory_tree_annotation_reader import DirectoryTreeAnnotationReader
-from .sc_annotation_reader import SCAnnotationReader
+from .geti_annotation_reader import GetiAnnotationReader
 
 __all__ = [
     "AnnotationReader",
     "DatumAnnotationReader",
-    "SCAnnotationReader",
+    "GetiAnnotationReader",
     "DirectoryTreeAnnotationReader",
 ]

--- a/geti_sdk/annotation_readers/base_annotation_reader.py
+++ b/geti_sdk/annotation_readers/base_annotation_reader.py
@@ -19,6 +19,7 @@ from typing import Dict, List, Optional, Union
 
 from geti_sdk.data_models.annotations import Annotation
 from geti_sdk.data_models.enums import TaskType
+from geti_sdk.data_models.media import MediaInformation
 
 
 class AnnotationReader:
@@ -44,6 +45,7 @@ class AnnotationReader:
         self,
         filename: str,
         label_name_to_id_mapping: dict,
+        media_information: MediaInformation,
         preserve_shape_for_global_labels: bool = False,
     ) -> List[Annotation]:
         """

--- a/geti_sdk/annotation_readers/datumaro_annotation_reader/datumaro_annotation_reader.py
+++ b/geti_sdk/annotation_readers/datumaro_annotation_reader/datumaro_annotation_reader.py
@@ -25,6 +25,7 @@ from geti_sdk.data_models.enums.task_type import GLOBAL_TASK_TYPES
 from geti_sdk.rest_converters import AnnotationRESTConverter
 from geti_sdk.utils import generate_segmentation_labels, get_dict_key_from_value
 
+from ...data_models.media import MediaInformation
 from .datumaro_dataset import DatumaroDataset
 
 
@@ -148,6 +149,7 @@ class DatumAnnotationReader(AnnotationReader):
         self,
         filename: str,
         label_name_to_id_mapping: dict,
+        media_information: MediaInformation,
         preserve_shape_for_global_labels: bool = False,
     ) -> List[SCAnnotation]:
         """
@@ -155,6 +157,8 @@ class DatumAnnotationReader(AnnotationReader):
 
         :param filename: name of the item to get the annotation data for.
         :param label_name_to_id_mapping: mapping of label name to label id.
+        :param media_information: MediaInformation object containing information
+            (e.g. width, height) about the media item to upload the annotation for
         :param preserve_shape_for_global_labels: False to convert shapes for global
             tasks to full rectangles (required for classification like tasks in
             Intel® Geti™ projects), True to preserve such shapes. This parameter

--- a/geti_sdk/annotation_readers/directory_tree_annotation_reader.py
+++ b/geti_sdk/annotation_readers/directory_tree_annotation_reader.py
@@ -17,11 +17,10 @@ import warnings
 from glob import glob
 from typing import Dict, List, Optional, Sequence, Set, Union
 
-import cv2
-
 from geti_sdk.annotation_readers import AnnotationReader
 from geti_sdk.data_models import Annotation, ScoredLabel, TaskType
 from geti_sdk.data_models.enums.media_type import SUPPORTED_IMAGE_FORMATS
+from geti_sdk.data_models.media import MediaInformation
 from geti_sdk.data_models.shapes import Rectangle
 
 
@@ -95,6 +94,7 @@ class DirectoryTreeAnnotationReader(AnnotationReader):
         self,
         filename: str,
         label_name_to_id_mapping: dict,
+        media_information: MediaInformation,
         preserve_shape_for_global_labels: bool = False,
         image_name_as_full_path: bool = False,
     ) -> List[Annotation]:
@@ -104,6 +104,8 @@ class DirectoryTreeAnnotationReader(AnnotationReader):
         :param filename: Name of the item to return the annotations for
         :param label_name_to_id_mapping: Dictionary mapping the name of a label to its
             unique database ID
+        :param media_information: MediaInformation object containing information
+            (e.g. width, height) about the media item to upload the annotation for
         :param preserve_shape_for_global_labels: Unused parameter in this type of
             annotation reader
         :param image_name_as_full_path: Set to True if the `filename` contains the
@@ -146,8 +148,6 @@ class DirectoryTreeAnnotationReader(AnnotationReader):
                 )
                 return []
             filepath = matches[0]
-        img = cv2.imread(filepath)
-        width, height = img.shape[1], img.shape[0]
         label_name = self.label_map[label_matches[0]]
         label = ScoredLabel(
             name=label_name,
@@ -157,7 +157,12 @@ class DirectoryTreeAnnotationReader(AnnotationReader):
         annotations.append(
             Annotation(
                 labels=[label],
-                shape=Rectangle(x=0, y=0, width=width, height=height),
+                shape=Rectangle(
+                    x=0,
+                    y=0,
+                    width=media_information.width,
+                    height=media_information.height,
+                ),
             )
         )
         return annotations

--- a/geti_sdk/geti.py
+++ b/geti_sdk/geti.py
@@ -23,7 +23,7 @@ import numpy as np
 from .annotation_readers import (
     AnnotationReader,
     DatumAnnotationReader,
-    SCAnnotationReader,
+    GetiAnnotationReader,
 )
 from .data_models import Image, Prediction, Project, TaskType, Video, VideoFrame
 from .data_models.containers import MediaList
@@ -322,6 +322,7 @@ class Geti:
         target_folder: str,
         project_name: Optional[str] = None,
         enable_auto_train: bool = True,
+        normalized_annotation_files: bool = False,
     ) -> Project:
         """
         Upload a previously downloaded Intel® Geti™ project to the server. This method
@@ -353,6 +354,8 @@ class Geti:
             after all annotations have been uploaded. This will directly trigger a
             training round if the conditions for auto-training are met. False to leave
             auto-training disabled for all tasks. Defaults to True.
+        :param normalized_annotation_files: Set this to True when uploading a project
+            that was downloaded from earlier (alpha) versions of Intel Geti.
         :return: Project object, holding information obtained from the cluster
             regarding the uploaded project
         """
@@ -392,11 +395,12 @@ class Geti:
             media_lists.append(videos)
 
         # Upload annotations
-        annotation_reader = SCAnnotationReader(
+        annotation_reader = GetiAnnotationReader(
             base_data_folder=os.path.join(target_folder, "annotations"),
             task_type=None,
+            use_legacy_annotation_format=normalized_annotation_files,
         )
-        annotation_client = AnnotationClient[SCAnnotationReader](
+        annotation_client = AnnotationClient[GetiAnnotationReader](
             session=self.session,
             project=project,
             workspace_id=self.workspace_id,

--- a/geti_sdk/rest_clients/annotation_clients/base_annotation_client.py
+++ b/geti_sdk/rest_clients/annotation_clients/base_annotation_client.py
@@ -304,6 +304,7 @@ class BaseAnnotationClient:
         annotation_list = self.annotation_reader.get_data(
             filename=media_item.name,
             label_name_to_id_mapping=self.label_mapping,
+            media_information=media_item.media_information,
             preserve_shape_for_global_labels=preserve_shape_for_global_labels,
         )
         return AnnotationRESTConverter.from_dict(

--- a/tests/integration/rest_clients/test_annotation_client.py
+++ b/tests/integration/rest_clients/test_annotation_client.py
@@ -6,7 +6,7 @@ from typing import List
 
 import pytest
 
-from geti_sdk.annotation_readers import SCAnnotationReader
+from geti_sdk.annotation_readers import GetiAnnotationReader
 from geti_sdk.data_models import AnnotationScene, Project, Video, VideoFrame
 from geti_sdk.data_models.enums import ShapeType
 from geti_sdk.rest_converters import AnnotationRESTConverter
@@ -79,7 +79,7 @@ class TestAnnotationClient:
         video = video_client.upload_video(video=fxt_video_path_1_light_bulbs)
 
         # Upload annotations for video
-        annotation_reader = SCAnnotationReader(
+        annotation_reader = GetiAnnotationReader(
             base_data_folder=fxt_light_bulbs_annotation_path
         )
 
@@ -191,7 +191,7 @@ class TestAnnotationClient:
         video_2 = video_client.upload_video(video=fxt_video_path_2_light_bulbs)
 
         # Upload annotations for video
-        annotation_reader = SCAnnotationReader(
+        annotation_reader = GetiAnnotationReader(
             base_data_folder=fxt_light_bulbs_annotation_path
         )
 
@@ -253,7 +253,7 @@ class TestAnnotationClient:
         image_2 = image_client.upload_image(fxt_image_path_2_light_bulbs)
 
         # Upload annotations for image
-        annotation_reader = SCAnnotationReader(
+        annotation_reader = GetiAnnotationReader(
             base_data_folder=fxt_light_bulbs_annotation_path
         )
 
@@ -312,7 +312,7 @@ class TestAnnotationClient:
             video=video, path_to_folder=temp_dir
         )
         # Get annotations for test directory
-        annotation_reader_from_temp_dir = SCAnnotationReader(
+        annotation_reader_from_temp_dir = GetiAnnotationReader(
             base_data_folder=annotations_temp_dir
         )
 


### PR DESCRIPTION
- Rename `sc_annotation_reader` to `geti_annotation_reader`
- Add support for the legacy normalized annotation format, so that projects from the alpha version of Geti can also be uploaded to the later versions