### PR TITLE
Update SDK platform version parsing mechanism

### DIFF
--- a/geti_sdk/http_session/geti_session.py
+++ b/geti_sdk/http_session/geti_session.py
@@ -20,11 +20,12 @@ from typing import Any, Dict, Optional, Union
 import requests
 import simplejson
 import urllib3
-from packaging import version
 from requests import Response
 from requests.exceptions import RequestException
 from requests.structures import CaseInsensitiveDict
 from urllib3.exceptions import InsecureRequestWarning
+
+from geti_sdk.platform_versions import GetiVersion
 
 from .exception import GetiRequestException
 from .server_config import LEGACY_API_VERSION, ServerCredentialConfig, ServerTokenConfig
@@ -93,14 +94,17 @@ class GetiSession(requests.Session):
         self._product_info = self._get_product_info_and_set_api_version()
 
     @property
-    def version(self) -> version.Version:
+    def version(self) -> GetiVersion:
         """
         Return the version of the Intel® Geti™ platform that is running on the server.
 
         :return: Version object holding the Intel® Geti™ version number
         """
-        version_string = self._product_info.get("product-version", "1.0.0")
-        return version.parse(version_string)
+        if "build-version" in self._product_info.keys():
+            version_string = self._product_info.get("build-version")
+        else:
+            version_string = self._product_info.get("product-version")
+        return GetiVersion(version_string)
 
     def _acquire_access_token(self) -> str:
         """

--- a/geti_sdk/platform_versions.py
+++ b/geti_sdk/platform_versions.py
@@ -11,8 +11,104 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions
 # and limitations under the License.
+from packaging.version import InvalidVersion, Version
 
-from packaging import version
 
-SC11_VERSION = version.parse("1.1.0-release-20220624125113")
-SC12_VERSION = version.parse("1.0.0")
+class GetiVersion:
+    """
+    Version identifier of the Intel Geti platform
+    """
+
+    _FIRST_GETI_HASH = "20220129184214"
+
+    def __init__(self, version_string: str) -> None:
+        """
+        Initialize the version
+
+        :param version_string: String representation of the version, as returned by
+            the Geti platform
+        """
+        version_parts = version_string.split("-")
+        if len(version_parts) == 3:
+            base_version = Version(version_parts[0])
+            tag = version_parts[1]
+            version_hash = version_parts[2]
+        elif len(version_parts) == 4:
+            base_version = Version(version_parts[0] + "-" + version_parts[1])
+            tag = version_parts[2]
+            version_hash = version_parts[3]
+        else:
+            raise InvalidVersion(
+                f"Unable to parse full platform version. Received '{version_string}'"
+            )
+        self.version = base_version
+        self.tag = tag
+        self.hash = version_hash
+
+    def __gt__(self, other):
+        """
+        Return True if this GetiVersion instance is a later version than `other`
+
+        :param other: GetiVersion object to compare with
+        :raises: TypeError if `other` is not a GetiVersion instance
+        :return: True if this instance corresponds to a later version of the Intel
+            Geti platform than `other`
+        """
+        if not isinstance(other, GetiVersion):
+            raise TypeError(
+                f"Unsupported comparison operation, {other} is not a GetiVersion."
+            )
+        return self.hash > other.hash
+
+    def __eq__(self, other):
+        """
+        Return True if this GetiVersion instance is equal to `other`
+
+        :param other: GetiVersion object to compare with
+        :raises: TypeError if `other` is not a GetiVersion instance
+        :return: True if this instance is equal to the GetiVersion passed in `other`
+        """
+        if not isinstance(other, GetiVersion):
+            raise TypeError(
+                f"Unsupported comparison operation, {other} is not a GetiVersion."
+            )
+        return (
+            self.hash == other.hash
+            and self.tag == other.tag
+            and self.version == other.version
+        )
+
+    @property
+    def is_sc_mvp(self) -> bool:
+        """
+        Return True if the version corresponds to a platform on the SC MVP version of
+        the software.
+        """
+        return self.version == Version("1.0.0") and self.hash <= self._FIRST_GETI_HASH
+
+    @property
+    def is_sc_1_1(self) -> bool:
+        """
+        Return True if the version corresponds to a platform on the SC v1.1 version of
+        the software.
+        """
+        return self.version == Version("1.1.0") and self.hash <= self._FIRST_GETI_HASH
+
+    @property
+    def is_geti_1_0(self) -> bool:
+        """
+        Return True if the version corresponds to a platform on the Geti version 1.0 of
+        the software.
+        """
+        return (
+            self.version.base_version == Version("1.0.0").base_version
+            and self.hash >= self._FIRST_GETI_HASH
+        )
+
+    @property
+    def is_geti(self) -> bool:
+        """
+        Return True if the version corresponds to any version of the Geti platform.
+        Return False if it corresponds to any SC version.
+        """
+        return self.version > Version("1.0.0b0") and self.hash >= self._FIRST_GETI_HASH

--- a/geti_sdk/rest_clients/annotation_clients/annotation_client.py
+++ b/geti_sdk/rest_clients/annotation_clients/annotation_client.py
@@ -17,7 +17,6 @@ from typing import Generic, List, Optional, Sequence, Union
 from geti_sdk.data_models import AnnotationScene, Image, Video, VideoFrame
 from geti_sdk.data_models.containers import MediaList
 from geti_sdk.http_session import GetiRequestException
-from geti_sdk.platform_versions import SC11_VERSION
 
 from .base_annotation_client import AnnotationReaderType, BaseAnnotationClient
 
@@ -47,7 +46,7 @@ class AnnotationClient(BaseAnnotationClient, Generic[AnnotationReaderType]):
                 return []
             else:
                 raise error
-        if self.session.version == SC11_VERSION:
+        if self.session.version.is_sc_1_1 or self.session.version.is_sc_mvp:
             annotations = response
         else:
             annotations = response["video_annotations"]

--- a/geti_sdk/rest_clients/annotation_clients/base_annotation_client.py
+++ b/geti_sdk/rest_clients/annotation_clients/base_annotation_client.py
@@ -30,7 +30,6 @@ from geti_sdk.data_models import (
 from geti_sdk.data_models.containers.media_list import MediaList
 from geti_sdk.data_models.media import MediaInformation
 from geti_sdk.http_session import GetiRequestException, GetiSession
-from geti_sdk.platform_versions import SC11_VERSION
 from geti_sdk.rest_converters import AnnotationRESTConverter
 from geti_sdk.rest_converters.annotation_rest_converter import (
     NormalizedAnnotationRESTConverter,
@@ -176,7 +175,7 @@ class BaseAnnotationClient:
                 )
         if scene_to_upload.annotations:
             scene_to_upload.prepare_for_post()
-            if self.session.version == SC11_VERSION:
+            if self.session.version.is_sc_mvp or self.session.version.is_sc_1_1:
                 rest_data = NormalizedAnnotationRESTConverter.to_normalized_dict(
                     scene_to_upload,
                     deidentify=False,
@@ -205,7 +204,7 @@ class BaseAnnotationClient:
             annotation applies
         :return: AnnotationScene object corresponding to the data in the response_dict
         """
-        if self.session.version == SC11_VERSION:
+        if self.session.version.is_sc_mvp or self.session.version.is_sc_1_1:
             annotation_scene = (
                 NormalizedAnnotationRESTConverter.normalized_annotation_scene_from_dict(
                     response_dict,
@@ -244,7 +243,7 @@ class BaseAnnotationClient:
         annotation_scene.extend(new_annotation_scene.annotations)
 
         if annotation_scene.has_data:
-            if self.session.version == SC11_VERSION:
+            if self.session.version.is_sc_mvp or self.session.version.is_sc_1_1:
                 rest_data = NormalizedAnnotationRESTConverter.to_normalized_dict(
                     annotation_scene,
                     deidentify=False,

--- a/geti_sdk/rest_clients/model_client.py
+++ b/geti_sdk/rest_clients/model_client.py
@@ -28,7 +28,6 @@ from geti_sdk.data_models import (
 )
 from geti_sdk.data_models.enums import JobState, JobType
 from geti_sdk.http_session import GetiSession
-from geti_sdk.platform_versions import SC11_VERSION
 from geti_sdk.rest_converters import ModelRESTConverter
 from geti_sdk.utils import get_supported_algorithms
 
@@ -56,7 +55,7 @@ class ModelClient:
         :return: List of model groups in the project
         """
         response = self.session.get_rest_response(url=self.base_url, method="GET")
-        if self.session.version == SC11_VERSION:
+        if self.session.version.is_sc_1_1 or self.session.version.is_sc_mvp:
             response_array = response["items"]
         else:
             response_array = response["model_groups"]
@@ -301,7 +300,7 @@ class ModelClient:
         :return: Model produced by the job
         """
         job.update(self.session)
-        if self.session.version == SC11_VERSION:
+        if self.session.version.is_sc_mvp or self.session.version.is_sc_1_1:
             job_pid = job.project_id
         else:
             job_pid = job.metadata.project.id

--- a/geti_sdk/rest_clients/prediction_client.py
+++ b/geti_sdk/rest_clients/prediction_client.py
@@ -30,7 +30,6 @@ from geti_sdk.data_models import (
 from geti_sdk.data_models.containers import MediaList
 from geti_sdk.data_models.enums import PredictionMode
 from geti_sdk.http_session import GetiRequestException, GetiSession
-from geti_sdk.platform_versions import SC11_VERSION
 from geti_sdk.rest_converters.prediction_rest_converter import (
     NormalizedPredictionRESTConverter,
     PredictionRESTConverter,
@@ -65,7 +64,7 @@ class PredictionClient:
         )
         model_info_array: List[Dict[str, Any]]
 
-        if self.session.version == SC11_VERSION:
+        if self.session.version.is_sc_1_1 or self.session.version.is_sc_mvp:
             if isinstance(response, dict):
                 model_info_array = response.get("items", [])
             elif isinstance(response, list):
@@ -165,7 +164,7 @@ class PredictionClient:
                     method="GET",
                 )
                 if isinstance(media_item, (Image, VideoFrame)):
-                    if self.session.version == SC11_VERSION:
+                    if self.session.version.is_sc_mvp or self.session.version.is_sc_1_1:
                         result = NormalizedPredictionRESTConverter.normalized_prediction_from_dict(
                             prediction=response,
                             image_height=media_item.media_information.height,
@@ -175,7 +174,7 @@ class PredictionClient:
                         result = PredictionRESTConverter.from_dict(response)
                     result.resolve_labels_for_result_media(labels=self._labels)
                 elif isinstance(media_item, Video):
-                    if self.session.version == SC11_VERSION:
+                    if self.session.version.is_sc_mvp or self.session.version.is_sc_1_1:
                         result = [
                             NormalizedPredictionRESTConverter.normalized_prediction_from_dict(
                                 prediction=prediction,

--- a/geti_sdk/rest_clients/project_client/project_client.py
+++ b/geti_sdk/rest_clients/project_client/project_client.py
@@ -21,7 +21,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from geti_sdk.data_models import Project, Task, TaskType
 from geti_sdk.data_models.utils import remove_null_fields
 from geti_sdk.http_session import GetiRequestException, GetiSession
-from geti_sdk.platform_versions import SC11_VERSION
 from geti_sdk.rest_converters import ProjectRESTConverter
 from geti_sdk.utils.project_helpers import get_task_types_by_project_type
 
@@ -72,7 +71,7 @@ class ProjectClient:
             url=f"{self.base_url}projects",
             method="GET",
         )
-        if self.session.version == SC11_VERSION:
+        if self.session.version.is_sc_mvp or self.session.version.is_sc_1_1:
             project_key = "items"
         else:
             project_key = "projects"

--- a/geti_sdk/rest_clients/training_client.py
+++ b/geti_sdk/rest_clients/training_client.py
@@ -27,7 +27,6 @@ from geti_sdk.data_models.containers import AlgorithmList
 from geti_sdk.data_models.enums import JobState
 from geti_sdk.data_models.project import Dataset
 from geti_sdk.http_session import GetiSession
-from geti_sdk.platform_versions import SC11_VERSION, SC12_VERSION
 from geti_sdk.rest_converters import (
     ConfigurationRESTConverter,
     JobRESTConverter,
@@ -76,7 +75,7 @@ class TrainingClient:
             url=f"workspaces/{self.workspace_id}/jobs", method="GET"
         )
         job_list: List[Job] = []
-        if self.session.version == SC11_VERSION:
+        if self.session.version.is_sc_mvp or self.session.version.is_sc_1_1:
             response_list_key = "items"
         else:
             response_list_key = "jobs"
@@ -85,9 +84,11 @@ class TrainingClient:
             job.workspace_id = self.workspace_id
             job_list.append(job)
 
-        if project_only and self.session.version == SC11_VERSION:
+        if project_only and (
+            self.session.version.is_sc_mvp or self.session.version.is_sc_1_1
+        ):
             return [job for job in job_list if job.project_id == self.project.id]
-        elif project_only and self.session.version >= SC12_VERSION:
+        elif project_only and self.session.version.is_geti:
             return [
                 job for job in job_list if job.metadata.project.id == self.project.id
             ]
@@ -169,7 +170,7 @@ class TrainingClient:
                 }
             )
 
-        if self.session.version == SC11_VERSION:
+        if self.session.version.is_sc_1_1 or self.session.version.is_sc_mvp:
             data = [request_data]
         else:
             data = {"training_parameters": [request_data]}

--- a/geti_sdk/utils/workspace_helpers.py
+++ b/geti_sdk/utils/workspace_helpers.py
@@ -13,7 +13,6 @@
 # and limitations under the License.
 
 from geti_sdk.http_session import GetiSession
-from geti_sdk.platform_versions import SC11_VERSION
 
 
 def get_default_workspace_id(rest_session: GetiSession) -> str:
@@ -27,7 +26,7 @@ def get_default_workspace_id(rest_session: GetiSession) -> str:
     if isinstance(workspaces, list):
         workspace_list = workspaces
     elif isinstance(workspaces, dict):
-        if rest_session.version == SC11_VERSION:
+        if rest_session.version.is_sc_mvp or rest_session.version.is_sc_1_1:
             workspace_list = workspaces["items"]
         else:
             workspace_list = workspaces["workspaces"]

--- a/tests/integration/http_session/test_geti_session.py
+++ b/tests/integration/http_session/test_geti_session.py
@@ -15,7 +15,6 @@ import pytest
 
 from geti_sdk.http_session import GetiSession
 from geti_sdk.http_session.geti_session import INITIAL_HEADERS
-from geti_sdk.platform_versions import SC11_VERSION, SC12_VERSION
 
 
 class TestGetiSession:
@@ -30,11 +29,12 @@ class TestGetiSession:
         Test that the 'version' attribute of the session is assigned a valid product
         version
         """
-        known_versions = [SC11_VERSION, SC12_VERSION]
-        version_matches = [
-            fxt_geti_session.version >= version for version in known_versions
+        version_tests = [
+            fxt_geti_session.version.is_sc_mvp,
+            fxt_geti_session.version.is_sc_1_1,
+            fxt_geti_session.version.is_geti and fxt_geti_session.version.is_geti_1_0,
         ]
-        assert sum(version_matches) >= 1
+        assert sum(version_tests) == 1
 
     @pytest.mark.vcr()
     def test_logout(self, fxt_geti_session: GetiSession):


### PR DESCRIPTION
- Remove the dependency on `version.parse`,  which can return a deprecated LegacyVersion object in case the version pattern does not match
- Parse full build version returned by the platform and use that to perform version comparisons