### PR TITLE
Auto detect normalized annotation files for GetiAnnotationReader

### DIFF
--- a/geti_sdk/annotation_readers/base_annotation_reader.py
+++ b/geti_sdk/annotation_readers/base_annotation_reader.py
@@ -40,6 +40,8 @@ class AnnotationReader:
         self.annotation_format = annotation_format
         self.task_type = task_type
 
+        self._filepaths: Optional[List[str]] = None
+
     @abstractmethod
     def get_data(
         self,
@@ -60,10 +62,15 @@ class AnnotationReader:
         :return: List of filenames (excluding extension) for all annotation files in
             the data folder
         """
-        filepaths = glob(os.path.join(self.base_folder, f"*{self.annotation_format}"))
-        return [
-            os.path.splitext(os.path.basename(filepath))[0] for filepath in filepaths
-        ]
+        if self._filepaths is None:
+            filepaths = glob(
+                os.path.join(self.base_folder, f"*{self.annotation_format}")
+            )
+            self._filepaths = [
+                os.path.splitext(os.path.basename(filepath))[0]
+                for filepath in filepaths
+            ]
+        return self._filepaths
 
     @abstractmethod
     def get_all_label_names(self) -> List[str]:

--- a/geti_sdk/data_models/shapes.py
+++ b/geti_sdk/data_models/shapes.py
@@ -228,6 +228,26 @@ class Rectangle(Shape):
         """
         return self.width * self.height
 
+    @property
+    def x_max(self) -> int:
+        """
+        Return the value of the maximal x-coordinate that the Rectangle instance
+        touches.
+
+        :return: Maximum x-coordinate for the rectangle
+        """
+        return self.x + self.width
+
+    @property
+    def y_max(self) -> int:
+        """
+        Return the value of the maximal y-coordinate that the Rectangle instance
+        touches.
+
+        :return: Maximum y-coordinate for the rectangle
+        """
+        return self.y + self.height
+
 
 @attr.s(auto_attribs=True)
 class Ellipse(Shape):
@@ -323,6 +343,26 @@ class Ellipse(Shape):
         """
         return self.width * self.height * math.pi
 
+    @property
+    def x_max(self) -> int:
+        """
+        Return the value of the maximal x-coordinate that the Ellipse instance
+        touches.
+
+        :return: Maximum x-coordinate for the ellipse
+        """
+        return self.x + self.width
+
+    @property
+    def y_max(self) -> int:
+        """
+        Return the value of the maximal y-coordinate that the Ellipse instance
+        touches.
+
+        :return: Maximum y-coordinate for the ellipse
+        """
+        return self.y + self.height
+
 
 @attr.s(auto_attribs=True)
 class Point:
@@ -359,6 +399,8 @@ class Polygon(Shape):
         Initialize private attributes.
         """
         self._contour: Optional[np.ndarray] = None
+        self._x_max: Optional[int] = None
+        self._y_max: Optional[int] = None
 
     def points_as_contour(self) -> np.ndarray:
         """
@@ -457,6 +499,35 @@ class Polygon(Shape):
         :return: area of the polygon
         """
         return cv2.contourArea(self.points_as_contour())
+
+    def _calculate_xy_max(self):
+        """
+        Calculate the maximum x and y coordinates that the Polyon touches, in pixels.
+        """
+        coord_maxes = self.points_as_contour().max(axis=0)
+        self._x_max, self._y_max = coord_maxes[0], coord_maxes[1]
+
+    @property
+    def x_max(self) -> int:
+        """
+        Return the maximum x-coordinate of the Polygon, in pixels
+
+        :return: largest x-coordinate that the polygon touches
+        """
+        if self._x_max is None:
+            self._calculate_xy_max()
+        return self._x_max
+
+    @property
+    def y_max(self) -> int:
+        """
+        Return the maximum y-coordinate of the Polygon, in pixels
+
+        :return: largest y-coordinate that the polygon touches
+        """
+        if self._y_max is None:
+            self._calculate_xy_max()
+        return self._y_max
 
     def fit_rotated_rectangle(self) -> "RotatedRectangle":
         """

--- a/geti_sdk/geti.py
+++ b/geti_sdk/geti.py
@@ -322,7 +322,6 @@ class Geti:
         target_folder: str,
         project_name: Optional[str] = None,
         enable_auto_train: bool = True,
-        normalized_annotation_files: bool = False,
     ) -> Project:
         """
         Upload a previously downloaded Intel® Geti™ project to the server. This method
@@ -354,8 +353,6 @@ class Geti:
             after all annotations have been uploaded. This will directly trigger a
             training round if the conditions for auto-training are met. False to leave
             auto-training disabled for all tasks. Defaults to True.
-        :param normalized_annotation_files: Set this to True when uploading a project
-            that was downloaded from earlier (alpha) versions of Intel Geti.
         :return: Project object, holding information obtained from the cluster
             regarding the uploaded project
         """
@@ -398,7 +395,6 @@ class Geti:
         annotation_reader = GetiAnnotationReader(
             base_data_folder=os.path.join(target_folder, "annotations"),
             task_type=None,
-            use_legacy_annotation_format=normalized_annotation_files,
         )
         annotation_client = AnnotationClient[GetiAnnotationReader](
             session=self.session,


### PR DESCRIPTION
If a project is downloaded from an old version of the Geti platform, the annotation files will be in a normalized coordinate system. The newer version of Geti uses a pixel coordinate system. The `GetiAnnotationReader` now auto-detects whether it is reading data for normalized or pixel coordinates, and creates the annotations accordingly.