### PR TITLE
Updated Attrs Classes and Fields

### DIFF
--- a/geti_sdk/data_models/algorithms.py
+++ b/geti_sdk/data_models/algorithms.py
@@ -20,7 +20,7 @@ from geti_sdk.data_models.enums import Domain, TaskType
 from geti_sdk.data_models.utils import str_to_optional_enum_converter
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class Algorithm:
     """
     Representation of a supported algorithm on the Intel® Geti™ platform.
@@ -31,11 +31,11 @@ class Algorithm:
     model_template_id: str
     gigaflops: float
     summary: Optional[str] = None
-    domain: Optional[str] = attr.ib(
+    domain: Optional[str] = attr.field(
         default=None, converter=str_to_optional_enum_converter(Domain)
     )
     # `domain` is deprecated in SC1.1, replaced by task_type
-    task_type: Optional[str] = attr.ib(
+    task_type: Optional[str] = attr.field(
         default=None, converter=str_to_optional_enum_converter(TaskType)
     )
     supports_auto_hpo: Optional[bool] = None

--- a/geti_sdk/data_models/algorithms.py
+++ b/geti_sdk/data_models/algorithms.py
@@ -20,7 +20,7 @@ from geti_sdk.data_models.enums import Domain, TaskType
 from geti_sdk.data_models.utils import str_to_optional_enum_converter
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class Algorithm:
     """
     Representation of a supported algorithm on the Intel® Geti™ platform.

--- a/geti_sdk/data_models/annotation_scene.py
+++ b/geti_sdk/data_models/annotation_scene.py
@@ -44,7 +44,7 @@ from geti_sdk.data_models.utils import (
 )
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class AnnotationScene:
     """
     Representation of an annotation scen for a certain media entity in GETi. An

--- a/geti_sdk/data_models/annotation_scene.py
+++ b/geti_sdk/data_models/annotation_scene.py
@@ -44,7 +44,7 @@ from geti_sdk.data_models.utils import (
 )
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class AnnotationScene:
     """
     Representation of an annotation scen for a certain media entity in GETi. An
@@ -70,12 +70,12 @@ class AnnotationScene:
     _GET_only_fields: ClassVar[List[str]] = ["annotation_state_per_task"]
 
     annotations: List[Annotation]
-    kind: str = attr.ib(
+    kind: str = attr.field(
         converter=str_to_annotation_kind, default=AnnotationKind.ANNOTATION
     )
     media_identifier: Optional[Union[ImageIdentifier, VideoFrameIdentifier]] = None
     id: Optional[str] = None
-    modified: Optional[str] = attr.ib(converter=str_to_datetime, default=None)
+    modified: Optional[str] = attr.field(converter=str_to_datetime, default=None)
     labels_to_revisit_full_scene: Optional[List[str]] = None
     annotation_state_per_task: Optional[List[TaskAnnotationState]] = None
 

--- a/geti_sdk/data_models/annotations.py
+++ b/geti_sdk/data_models/annotations.py
@@ -28,7 +28,7 @@ from geti_sdk.data_models.shapes import (
 from geti_sdk.data_models.utils import deidentify, str_to_datetime
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class Annotation:
     """
     Representation of a single annotation for a media item on the Intel® Geti™ platform.

--- a/geti_sdk/data_models/annotations.py
+++ b/geti_sdk/data_models/annotations.py
@@ -28,7 +28,7 @@ from geti_sdk.data_models.shapes import (
 from geti_sdk.data_models.utils import deidentify, str_to_datetime
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class Annotation:
     """
     Representation of a single annotation for a media item on the Intel® Geti™ platform.
@@ -45,7 +45,7 @@ class Annotation:
 
     labels: List[ScoredLabel]
     shape: Union[Rectangle, Ellipse, Polygon, RotatedRectangle]
-    modified: Optional[str] = attr.ib(converter=str_to_datetime, default=None)
+    modified: Optional[str] = attr.field(converter=str_to_datetime, default=None)
     id: Optional[str] = None
     labels_to_revisit: Optional[List[str]] = None
 

--- a/geti_sdk/data_models/configurable_parameter.py
+++ b/geti_sdk/data_models/configurable_parameter.py
@@ -28,7 +28,7 @@ from geti_sdk.data_models.utils import (
 )
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class ConfigurableParameter:
     """
     Representation of a generic configurable parameter in GETi.
@@ -109,7 +109,7 @@ class ConfigurableParameter:
         return pformat(overview_dict)
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class ConfigurableBoolean(ConfigurableParameter):
     """
     Representation of a configurable boolean in GETi.
@@ -119,7 +119,7 @@ class ConfigurableBoolean(ConfigurableParameter):
     value: bool = attr.field(kw_only=True)
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class ConfigurableInteger(ConfigurableParameter):
     """
     Representation of a configurable integer in GETi.
@@ -134,7 +134,7 @@ class ConfigurableInteger(ConfigurableParameter):
     max_value: Optional[int] = attr.field(default=None, kw_only=True)
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class ConfigurableFloat(ConfigurableParameter):
     """
     Representation of a configurable float in GETi.
@@ -149,7 +149,7 @@ class ConfigurableFloat(ConfigurableParameter):
     max_value: float = attr.field(kw_only=True)
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class SelectableFloat(ConfigurableParameter):
     """
     Representation of a float selectable configurable parameter in GETi.
@@ -162,7 +162,7 @@ class SelectableFloat(ConfigurableParameter):
     options: List[float] = attr.field(kw_only=True)
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class SelectableString(ConfigurableParameter):
     """
     Representation of a string selectable configurable parameter in GETi.

--- a/geti_sdk/data_models/configurable_parameter.py
+++ b/geti_sdk/data_models/configurable_parameter.py
@@ -28,7 +28,7 @@ from geti_sdk.data_models.utils import (
 )
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class ConfigurableParameter:
     """
     Representation of a generic configurable parameter in GETi.
@@ -62,14 +62,14 @@ class ConfigurableParameter:
 
     name: str
     value: Union[str, bool, float, int]
-    data_type: Optional[str] = attr.ib(
+    data_type: Optional[str] = attr.field(
         default=None, converter=str_to_enum_converter(ParameterDataType)
     )
     default_value: Optional[Union[str, bool, float, int]] = None
     description: Optional[str] = None
     editable: Optional[bool] = None
     header: Optional[str] = None
-    template_type: Optional[str] = attr.ib(
+    template_type: Optional[str] = attr.field(
         default=None, converter=str_to_enum_converter(ParameterInputType)
     )
     ui_rules: Optional[Dict[str, Any]] = None
@@ -109,17 +109,17 @@ class ConfigurableParameter:
         return pformat(overview_dict)
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class ConfigurableBoolean(ConfigurableParameter):
     """
     Representation of a configurable boolean in GETi.
     """
 
-    default_value: Optional[bool] = attr.ib(default=None, kw_only=True)
-    value: bool = attr.ib(kw_only=True)
+    default_value: Optional[bool] = attr.field(default=None, kw_only=True)
+    value: bool = attr.field(kw_only=True)
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class ConfigurableInteger(ConfigurableParameter):
     """
     Representation of a configurable integer in GETi.
@@ -128,13 +128,13 @@ class ConfigurableInteger(ConfigurableParameter):
     :var max_value: Maximum value allowed to be set for the configurable integer
     """
 
-    default_value: Optional[int] = attr.ib(default=None, kw_only=True)
-    value: int = attr.ib(kw_only=True)
-    min_value: Optional[int] = attr.ib(default=None, kw_only=True)
-    max_value: Optional[int] = attr.ib(default=None, kw_only=True)
+    default_value: Optional[int] = attr.field(default=None, kw_only=True)
+    value: int = attr.field(kw_only=True)
+    min_value: Optional[int] = attr.field(default=None, kw_only=True)
+    max_value: Optional[int] = attr.field(default=None, kw_only=True)
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class ConfigurableFloat(ConfigurableParameter):
     """
     Representation of a configurable float in GETi.
@@ -143,13 +143,13 @@ class ConfigurableFloat(ConfigurableParameter):
     :var max_value: Maximum value allowed to be set for the configurable float
     """
 
-    default_value: Optional[float] = attr.ib(kw_only=True, default=None)
-    value: float = attr.ib(kw_only=True)
-    min_value: float = attr.ib(kw_only=True)
-    max_value: float = attr.ib(kw_only=True)
+    default_value: Optional[float] = attr.field(kw_only=True, default=None)
+    value: float = attr.field(kw_only=True)
+    min_value: float = attr.field(kw_only=True)
+    max_value: float = attr.field(kw_only=True)
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class SelectableFloat(ConfigurableParameter):
     """
     Representation of a float selectable configurable parameter in GETi.
@@ -157,12 +157,12 @@ class SelectableFloat(ConfigurableParameter):
     :var options: List of options that the selectable float is allowed to take
     """
 
-    default_value: Optional[float] = attr.ib(kw_only=True, default=None)
-    value: float = attr.ib(kw_only=True)
-    options: List[float] = attr.ib(kw_only=True)
+    default_value: Optional[float] = attr.field(kw_only=True, default=None)
+    value: float = attr.field(kw_only=True)
+    options: List[float] = attr.field(kw_only=True)
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class SelectableString(ConfigurableParameter):
     """
     Representation of a string selectable configurable parameter in GETi.
@@ -170,7 +170,7 @@ class SelectableString(ConfigurableParameter):
     :var options: List of options that the selectable string is allowed to take
     """
 
-    default_value: Optional[str] = attr.ib(kw_only=True, default=None)
-    enum_name: str = attr.ib(kw_only=True)
-    value: str = attr.ib(kw_only=True)
-    options: List[str] = attr.ib(kw_only=True)
+    default_value: Optional[str] = attr.field(kw_only=True, default=None)
+    enum_name: str = attr.field(kw_only=True)
+    value: str = attr.field(kw_only=True)
+    options: List[str] = attr.field(kw_only=True)

--- a/geti_sdk/data_models/configurable_parameter_group.py
+++ b/geti_sdk/data_models/configurable_parameter_group.py
@@ -107,7 +107,7 @@ def _parameter_dicts_to_list(
     return parameters
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class ParameterGroup:
     """
     Representation of a group of configurable parameters in GETi, as returned by the

--- a/geti_sdk/data_models/configurable_parameter_group.py
+++ b/geti_sdk/data_models/configurable_parameter_group.py
@@ -107,7 +107,7 @@ def _parameter_dicts_to_list(
     return parameters
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class ParameterGroup:
     """
     Representation of a group of configurable parameters in GETi, as returned by the
@@ -123,7 +123,7 @@ class ParameterGroup:
     _non_minimal_fields: ClassVar[List[str]] = ["description"]
 
     header: str
-    type: str = attr.ib(converter=str_to_enum_converter(ConfigurableParameterType))
+    type: str = attr.field(converter=str_to_enum_converter(ConfigurableParameterType))
     description: Optional[str] = None
     parameters: Optional[Sequence[PARAMETER_TYPES]] = None
     name: Optional[str] = None

--- a/geti_sdk/data_models/configuration.py
+++ b/geti_sdk/data_models/configuration.py
@@ -28,7 +28,7 @@ from geti_sdk.data_models.configuration_identifiers import (
 from geti_sdk.data_models.utils import attr_value_serializer, deidentify
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class ConfigurableParameters(ParameterGroup):
     """
     Representation of configurable parameters in GETi, as returned by the
@@ -43,8 +43,8 @@ class ConfigurableParameters(ParameterGroup):
 
     entity_identifier: Union[
         HyperParameterGroupIdentifier, ComponentEntityIdentifier
-    ] = attr.ib(kw_only=True)
-    id: Optional[str] = attr.ib(default=None, kw_only=True)
+    ] = attr.field(kw_only=True)
+    id: Optional[str] = attr.field(default=None, kw_only=True)
 
     def deidentify(self) -> None:
         """
@@ -55,7 +55,7 @@ class ConfigurableParameters(ParameterGroup):
         deidentify(self.entity_identifier)
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True, slots=False)
 class Configuration:
     """
     Representation of a set of configurable parameters in GETi, that apply to a project
@@ -207,7 +207,7 @@ class Configuration:
         )
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class GlobalConfiguration(Configuration):
     """
     Representation of the project-wide configurable parameters for a project in GETi.
@@ -260,7 +260,7 @@ class GlobalConfiguration(Configuration):
         return summary_str
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class TaskConfiguration(Configuration):
     """
     Representation of the configurable parameters for a task in GETi.
@@ -268,8 +268,8 @@ class TaskConfiguration(Configuration):
 
     _identifier_fields: ClassVar[List[str]] = ["task_id"]
 
-    task_id: Optional[str] = attr.ib(default=None, kw_only=True)
-    task_title: str = attr.ib(kw_only=True)
+    task_id: Optional[str] = attr.field(default=None, kw_only=True)
+    task_title: str = attr.field(kw_only=True)
 
     @property
     def model_configurations(self) -> List[ConfigurableParameters]:
@@ -353,7 +353,7 @@ class TaskConfiguration(Configuration):
         return summary_str
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class FullConfiguration:
     """
     Representation of the full configuration (both global and task-chain) for a

--- a/geti_sdk/data_models/configuration.py
+++ b/geti_sdk/data_models/configuration.py
@@ -28,7 +28,7 @@ from geti_sdk.data_models.configuration_identifiers import (
 from geti_sdk.data_models.utils import attr_value_serializer, deidentify
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class ConfigurableParameters(ParameterGroup):
     """
     Representation of configurable parameters in GETi, as returned by the
@@ -55,7 +55,7 @@ class ConfigurableParameters(ParameterGroup):
         deidentify(self.entity_identifier)
 
 
-@attr.define(auto_attribs=True, slots=False)
+@attr.define(slots=False)
 class Configuration:
     """
     Representation of a set of configurable parameters in GETi, that apply to a project
@@ -207,7 +207,7 @@ class Configuration:
         )
 
 
-@attr.define(auto_attribs=True)
+@attr.define(slots=False)
 class GlobalConfiguration(Configuration):
     """
     Representation of the project-wide configurable parameters for a project in GETi.
@@ -260,7 +260,7 @@ class GlobalConfiguration(Configuration):
         return summary_str
 
 
-@attr.define(auto_attribs=True)
+@attr.define(slots=False)
 class TaskConfiguration(Configuration):
     """
     Representation of the configurable parameters for a task in GETi.
@@ -353,7 +353,7 @@ class TaskConfiguration(Configuration):
         return summary_str
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class FullConfiguration:
     """
     Representation of the full configuration (both global and task-chain) for a

--- a/geti_sdk/data_models/configuration_identifiers.py
+++ b/geti_sdk/data_models/configuration_identifiers.py
@@ -21,7 +21,7 @@ from geti_sdk.data_models.enums import ConfigurationEntityType
 from geti_sdk.data_models.utils import attr_value_serializer, str_to_enum_converter
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class EntityIdentifier:
     """
     Identifying information for a configurable entity on the Intel® Geti™ platform,
@@ -45,7 +45,7 @@ class EntityIdentifier:
         return attr.asdict(self, value_serializer=attr_value_serializer, recurse=True)
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class HyperParameterGroupIdentifier(EntityIdentifier):
     """
     Identifying information for a HyperParameterGroup on the Intel® Geti™ platform,
@@ -75,7 +75,7 @@ class HyperParameterGroupIdentifier(EntityIdentifier):
         self.model_template_id = algorithm.model_template_id
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class ComponentEntityIdentifier(EntityIdentifier):
     """
     Identifying information for a configurable Component on the Intel® Geti™ platform,

--- a/geti_sdk/data_models/configuration_identifiers.py
+++ b/geti_sdk/data_models/configuration_identifiers.py
@@ -21,7 +21,7 @@ from geti_sdk.data_models.enums import ConfigurationEntityType
 from geti_sdk.data_models.utils import attr_value_serializer, str_to_enum_converter
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class EntityIdentifier:
     """
     Identifying information for a configurable entity on the Intel® Geti™ platform,
@@ -33,7 +33,7 @@ class EntityIdentifier:
 
     _identifier_fields: ClassVar[str] = ["workspace_id"]
 
-    type: str = attr.ib(converter=str_to_enum_converter(ConfigurationEntityType))
+    type: str = attr.field(converter=str_to_enum_converter(ConfigurationEntityType))
     workspace_id: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
@@ -45,7 +45,7 @@ class EntityIdentifier:
         return attr.asdict(self, value_serializer=attr_value_serializer, recurse=True)
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class HyperParameterGroupIdentifier(EntityIdentifier):
     """
     Identifying information for a HyperParameterGroup on the Intel® Geti™ platform,
@@ -58,10 +58,10 @@ class HyperParameterGroupIdentifier(EntityIdentifier):
 
     _identifier_fields: ClassVar[str] = ["model_storage_id", "workspace_id"]
 
-    group_name: str = attr.ib(kw_only=True)
+    group_name: str = attr.field(kw_only=True)
     model_storage_id: Optional[str] = None
-    algorithm_name: Optional[str] = attr.ib(repr=False, default=None)
-    model_template_id: Optional[str] = attr.ib(repr=False, default=None)
+    algorithm_name: Optional[str] = attr.field(repr=False, default=None)
+    model_template_id: Optional[str] = attr.field(repr=False, default=None)
 
     def resolve_algorithm(self, algorithm: Algorithm):
         """
@@ -75,7 +75,7 @@ class HyperParameterGroupIdentifier(EntityIdentifier):
         self.model_template_id = algorithm.model_template_id
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class ComponentEntityIdentifier(EntityIdentifier):
     """
     Identifying information for a configurable Component on the Intel® Geti™ platform,
@@ -88,6 +88,6 @@ class ComponentEntityIdentifier(EntityIdentifier):
 
     _identifier_fields: ClassVar[str] = ["project_id", "task_id", "workspace_id"]
 
-    component: str = attr.ib(kw_only=True)
+    component: str = attr.field(kw_only=True)
     project_id: Optional[str] = None
     task_id: Optional[str] = None

--- a/geti_sdk/data_models/job.py
+++ b/geti_sdk/data_models/job.py
@@ -28,7 +28,7 @@ from geti_sdk.data_models.utils import (
 from geti_sdk.http_session import GetiRequestException, GetiSession
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class JobStatus(StatusSummary):
     """
     Current status of a job on the Intel® Geti™ server.
@@ -50,7 +50,7 @@ class JobStatus(StatusSummary):
         return cls(**status_dict)
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class TaskMetadata:
     """
     Metadata related to a task on the Intel® Geti™ cluster.
@@ -69,7 +69,7 @@ class TaskMetadata:
     dataset_storage_id: Optional[str] = None
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class TestMetadata:
     """
     Metadata related to a model test job on the GETi cluster.
@@ -85,7 +85,7 @@ class TestMetadata:
     datasets: List[Dataset]
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class ProjectMetadata:
     """
     Metadata related to a project on the GETi cluster.
@@ -98,7 +98,7 @@ class ProjectMetadata:
     id: Optional[str] = None
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class JobMetadata:
     """
     Metadata for a particular job on the GETi cluster.
@@ -124,7 +124,7 @@ class JobMetadata:
     optimized_model_id: Optional[str] = None
 
 
-@attr.define(auto_attribs=True, slots=False)
+@attr.define(slots=False)
 class Job:
     """
     Representation of a job running on the GETi cluster.

--- a/geti_sdk/data_models/job.py
+++ b/geti_sdk/data_models/job.py
@@ -28,7 +28,7 @@ from geti_sdk.data_models.utils import (
 from geti_sdk.http_session import GetiRequestException, GetiSession
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class JobStatus(StatusSummary):
     """
     Current status of a job on the Intel® Geti™ server.
@@ -36,7 +36,7 @@ class JobStatus(StatusSummary):
     :var state: Current state of the job
     """
 
-    state: str = attr.ib(converter=str_to_enum_converter(JobState))
+    state: str = attr.field(converter=str_to_enum_converter(JobState))
 
     @classmethod
     def from_dict(cls, status_dict: Dict[str, Any]) -> "JobStatus":
@@ -50,7 +50,7 @@ class JobStatus(StatusSummary):
         return cls(**status_dict)
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class TaskMetadata:
     """
     Metadata related to a task on the Intel® Geti™ cluster.
@@ -69,7 +69,7 @@ class TaskMetadata:
     dataset_storage_id: Optional[str] = None
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class TestMetadata:
     """
     Metadata related to a model test job on the GETi cluster.
@@ -85,7 +85,7 @@ class TestMetadata:
     datasets: List[Dataset]
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class ProjectMetadata:
     """
     Metadata related to a project on the GETi cluster.
@@ -98,7 +98,7 @@ class ProjectMetadata:
     id: Optional[str] = None
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class JobMetadata:
     """
     Metadata for a particular job on the GETi cluster.
@@ -124,7 +124,7 @@ class JobMetadata:
     optimized_model_id: Optional[str] = None
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True, slots=False)
 class Job:
     """
     Representation of a job running on the GETi cluster.
@@ -142,10 +142,10 @@ class Job:
     description: str
     id: str
     status: JobStatus
-    type: str = attr.ib(converter=str_to_enum_converter(JobType))
+    type: str = attr.field(converter=str_to_enum_converter(JobType))
     metadata: JobMetadata
     project_id: Optional[str] = None
-    creation_time: Optional[str] = attr.ib(converter=str_to_datetime, default=None)
+    creation_time: Optional[str] = attr.field(converter=str_to_datetime, default=None)
 
     def __attrs_post_init__(self):
         """

--- a/geti_sdk/data_models/label.py
+++ b/geti_sdk/data_models/label.py
@@ -23,7 +23,7 @@ from ote_sdk.entities.scored_label import ScoredLabel as OteScoredLabel
 from geti_sdk.data_models.enums import TaskType
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class LabelSource:
     """
     Representation of a source for a ScoredLabel in GETi
@@ -41,7 +41,7 @@ class LabelSource:
     type: Optional[str] = None
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class Label:
     """
     Representation of a Label in GETi.
@@ -81,7 +81,7 @@ class Label:
         )
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class ScoredLabel:
     """
     Representation of a Label with an assigned probability in GETi.

--- a/geti_sdk/data_models/label.py
+++ b/geti_sdk/data_models/label.py
@@ -23,7 +23,7 @@ from ote_sdk.entities.scored_label import ScoredLabel as OteScoredLabel
 from geti_sdk.data_models.enums import TaskType
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class LabelSource:
     """
     Representation of a source for a ScoredLabel in GETi
@@ -41,7 +41,7 @@ class LabelSource:
     type: Optional[str] = None
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class Label:
     """
     Representation of a Label in GETi.
@@ -81,7 +81,7 @@ class Label:
         )
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class ScoredLabel:
     """
     Representation of a Label with an assigned probability in GETi.

--- a/geti_sdk/data_models/media.py
+++ b/geti_sdk/data_models/media.py
@@ -40,7 +40,7 @@ from .utils import (
 )
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class MediaInformation:
     """
     Basic information about a media item in Intel® Geti™.
@@ -55,7 +55,7 @@ class MediaInformation:
     width: int
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class VideoInformation(MediaInformation):
     """
     Basic information about a video entity in Intel® Geti™.
@@ -70,7 +70,7 @@ class VideoInformation(MediaInformation):
     frame_stride: int
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class ImageInformation(MediaInformation):
     """
     Basic information about an image entity in Intel® Geti™
@@ -79,7 +79,7 @@ class ImageInformation(MediaInformation):
     pass
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class VideoFrameInformation(MediaInformation):
     """
     Basic information about a video frame in Intel® Geti™.
@@ -89,7 +89,7 @@ class VideoFrameInformation(MediaInformation):
     video_id: str
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class MediaItem:
     """
     Representation of a media entity in Intel® Geti™.
@@ -106,8 +106,8 @@ class MediaItem:
 
     id: str
     name: str
-    type: str = attr.ib(converter=str_to_media_type)
-    upload_time: str = attr.ib(converter=str_to_datetime)
+    type: str = attr.field(converter=str_to_media_type)
+    upload_time: str = attr.field(converter=str_to_datetime)
     media_information: MediaInformation
     state: Optional[str] = None
     # State is deprecated in SC1.1, replaced by `annotation_state_per_task`
@@ -194,7 +194,7 @@ class MediaItem:
         return pformat(self.to_dict())
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True, slots=False)
 class Image(MediaItem):
     """
     Representation of an image in Intel® Geti™.
@@ -203,7 +203,7 @@ class Image(MediaItem):
             height about the image entity
     """
 
-    media_information: ImageInformation = attr.ib(kw_only=True)
+    media_information: ImageInformation = attr.field(kw_only=True)
 
     def __attrs_post_init__(self):
         """
@@ -256,7 +256,7 @@ class Image(MediaItem):
         return self._data
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True, slots=False)
 class Video(MediaItem):
     """
     Representation of a video in Intel® Geti™.
@@ -265,7 +265,7 @@ class Video(MediaItem):
             height and duration about the video entity
     """
 
-    media_information: VideoInformation = attr.ib(kw_only=True)
+    media_information: VideoInformation = attr.field(kw_only=True)
 
     def __attrs_post_init__(self):
         """
@@ -366,7 +366,7 @@ class Video(MediaItem):
                 os.remove(self._data)
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True, slots=False)
 class VideoFrame(MediaItem):
     """
     Representation of a video frame in Intel® Geti™.
@@ -377,8 +377,8 @@ class VideoFrame(MediaItem):
         downloaded using the 'get_data' method
     """
 
-    media_information: VideoFrameInformation = attr.ib(kw_only=True)
-    video_name: Optional[str] = attr.ib(kw_only=True, default=None)
+    media_information: VideoFrameInformation = attr.field(kw_only=True)
+    video_name: Optional[str] = attr.field(kw_only=True, default=None)
 
     def __attrs_post_init__(self):
         """

--- a/geti_sdk/data_models/media.py
+++ b/geti_sdk/data_models/media.py
@@ -40,7 +40,7 @@ from .utils import (
 )
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class MediaInformation:
     """
     Basic information about a media item in Intel® Geti™.
@@ -55,7 +55,7 @@ class MediaInformation:
     width: int
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class VideoInformation(MediaInformation):
     """
     Basic information about a video entity in Intel® Geti™.
@@ -70,7 +70,7 @@ class VideoInformation(MediaInformation):
     frame_stride: int
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class ImageInformation(MediaInformation):
     """
     Basic information about an image entity in Intel® Geti™
@@ -79,7 +79,7 @@ class ImageInformation(MediaInformation):
     pass
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class VideoFrameInformation(MediaInformation):
     """
     Basic information about a video frame in Intel® Geti™.
@@ -89,7 +89,7 @@ class VideoFrameInformation(MediaInformation):
     video_id: str
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class MediaItem:
     """
     Representation of a media entity in Intel® Geti™.
@@ -194,7 +194,7 @@ class MediaItem:
         return pformat(self.to_dict())
 
 
-@attr.define(auto_attribs=True, slots=False)
+@attr.define(slots=False)
 class Image(MediaItem):
     """
     Representation of an image in Intel® Geti™.
@@ -256,7 +256,7 @@ class Image(MediaItem):
         return self._data
 
 
-@attr.define(auto_attribs=True, slots=False)
+@attr.define(slots=False)
 class Video(MediaItem):
     """
     Representation of a video in Intel® Geti™.
@@ -366,7 +366,7 @@ class Video(MediaItem):
                 os.remove(self._data)
 
 
-@attr.define(auto_attribs=True, slots=False)
+@attr.define(slots=False)
 class VideoFrame(MediaItem):
     """
     Representation of a video frame in Intel® Geti™.

--- a/geti_sdk/data_models/media_identifiers.py
+++ b/geti_sdk/data_models/media_identifiers.py
@@ -19,7 +19,7 @@ import attr
 from geti_sdk.data_models.utils import attr_value_serializer, str_to_media_type
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class MediaIdentifier:
     """
     Representation of media identification data as output by the Intel® Geti™
@@ -39,7 +39,7 @@ class MediaIdentifier:
         return attr.asdict(self, value_serializer=attr_value_serializer)
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class ImageIdentifier(MediaIdentifier):
     """
     Representation of image identification data used by the Intel® Geti™ /annotations
@@ -53,7 +53,7 @@ class ImageIdentifier(MediaIdentifier):
     image_id: str
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class VideoFrameIdentifier(MediaIdentifier):
     """
     Representation of video frame identification data used by the Intel® Geti™
@@ -70,7 +70,7 @@ class VideoFrameIdentifier(MediaIdentifier):
     video_id: str
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class VideoIdentifier(MediaIdentifier):
     """
     Representation of video identification data used by the Intel® Geti™ /annotations

--- a/geti_sdk/data_models/media_identifiers.py
+++ b/geti_sdk/data_models/media_identifiers.py
@@ -19,7 +19,7 @@ import attr
 from geti_sdk.data_models.utils import attr_value_serializer, str_to_media_type
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class MediaIdentifier:
     """
     Representation of media identification data as output by the Intel® Geti™
@@ -28,7 +28,7 @@ class MediaIdentifier:
     :var type: Type of the media to which the annotation belongs
     """
 
-    type: str = attr.ib(converter=str_to_media_type)
+    type: str = attr.field(converter=str_to_media_type)
 
     def to_dict(self) -> Dict[str, str]:
         """
@@ -39,7 +39,7 @@ class MediaIdentifier:
         return attr.asdict(self, value_serializer=attr_value_serializer)
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class ImageIdentifier(MediaIdentifier):
     """
     Representation of image identification data used by the Intel® Geti™ /annotations
@@ -53,7 +53,7 @@ class ImageIdentifier(MediaIdentifier):
     image_id: str
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class VideoFrameIdentifier(MediaIdentifier):
     """
     Representation of video frame identification data used by the Intel® Geti™
@@ -70,7 +70,7 @@ class VideoFrameIdentifier(MediaIdentifier):
     video_id: str
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class VideoIdentifier(MediaIdentifier):
     """
     Representation of video identification data used by the Intel® Geti™ /annotations

--- a/geti_sdk/data_models/model.py
+++ b/geti_sdk/data_models/model.py
@@ -33,7 +33,7 @@ from . import Label
 from .performance import Performance
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class OptimizationCapabilities:
     """
     Representation of the various model optimization capabilities in GETi.
@@ -44,7 +44,7 @@ class OptimizationCapabilities:
     is_filter_pruning_supported: Optional[bool] = None
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class BaseModel:
     """
     Representation of the basic information for a Model or OptimizedModel in GETi
@@ -174,7 +174,7 @@ class BaseModel:
         deidentify(self)
 
 
-@attr.define(auto_attribs=True, slots=False)
+@attr.define(slots=False)
 class OptimizedModel(BaseModel):
     """
     Representation of an OptimizedModel in Intel® Geti™. An optimized model is a trained model
@@ -194,7 +194,7 @@ class OptimizedModel(BaseModel):
     version: Optional[int] = attr.field(kw_only=True, default=None)
 
 
-@attr.define(auto_attribs=True, slots=False)
+@attr.define(slots=False)
 class Model(BaseModel):
     """
     Representation of a trained Model in Intel® Geti™.

--- a/geti_sdk/data_models/model.py
+++ b/geti_sdk/data_models/model.py
@@ -33,7 +33,7 @@ from . import Label
 from .performance import Performance
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class OptimizationCapabilities:
     """
     Representation of the various model optimization capabilities in GETi.
@@ -44,7 +44,7 @@ class OptimizationCapabilities:
     is_filter_pruning_supported: Optional[bool] = None
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class BaseModel:
     """
     Representation of the basic information for a Model or OptimizedModel in GETi
@@ -60,15 +60,15 @@ class BaseModel:
     fps_throughput: str
     latency: str
     precision: List[str]
-    creation_date: str = attr.ib(converter=str_to_datetime)
+    creation_date: str = attr.field(converter=str_to_datetime)
     size: Optional[int] = None
     target_device: Optional[str] = None
     target_device_type: Optional[str] = None
     previous_revision_id: Optional[str] = None
     previous_trained_revision_id: Optional[str] = None
-    score: Optional[float] = attr.ib(default=None)  # 'score' is removed in v1.1
+    score: Optional[float] = attr.field(default=None)  # 'score' is removed in v1.1
     performance: Optional[Performance] = None
-    id: Optional[str] = attr.ib(default=None)
+    id: Optional[str] = attr.field(default=None)
 
     def __attrs_post_init__(self):
         """
@@ -174,7 +174,7 @@ class BaseModel:
         deidentify(self)
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True, slots=False)
 class OptimizedModel(BaseModel):
     """
     Representation of an OptimizedModel in Intel® Geti™. An optimized model is a trained model
@@ -183,29 +183,29 @@ class OptimizedModel(BaseModel):
     OpenVINO.
     """
 
-    model_status: str = attr.ib(
+    model_status: str = attr.field(
         kw_only=True, converter=str_to_enum_converter(ModelStatus)
     )
-    optimization_methods: List[str] = attr.ib(kw_only=True)
-    optimization_objectives: Dict[str, Any] = attr.ib(kw_only=True)
-    optimization_type: str = attr.ib(
+    optimization_methods: List[str] = attr.field(kw_only=True)
+    optimization_objectives: Dict[str, Any] = attr.field(kw_only=True)
+    optimization_type: str = attr.field(
         kw_only=True, converter=str_to_enum_converter(OptimizationType)
     )
-    version: Optional[int] = attr.ib(kw_only=True, default=None)
+    version: Optional[int] = attr.field(kw_only=True, default=None)
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True, slots=False)
 class Model(BaseModel):
     """
     Representation of a trained Model in Intel® Geti™.
     """
 
-    architecture: str = attr.ib(kw_only=True)
-    score_up_to_date: bool = attr.ib(kw_only=True)
-    optimization_capabilities: OptimizationCapabilities = attr.ib(kw_only=True)
-    optimized_models: List[OptimizedModel] = attr.ib(kw_only=True)
+    architecture: str = attr.field(kw_only=True)
+    score_up_to_date: bool = attr.field(kw_only=True)
+    optimization_capabilities: OptimizationCapabilities = attr.field(kw_only=True)
+    optimized_models: List[OptimizedModel] = attr.field(kw_only=True)
     labels: Optional[List[Label]] = None
-    version: Optional[int] = attr.ib(default=None, kw_only=True)
+    version: Optional[int] = attr.field(default=None, kw_only=True)
     # 'version' is deprecated in v1.1
     training_dataset_info: Optional[Dict[str, str]] = None
 

--- a/geti_sdk/data_models/model_group.py
+++ b/geti_sdk/data_models/model_group.py
@@ -25,7 +25,7 @@ from geti_sdk.http_session import GetiSession
 from geti_sdk.utils.algorithm_helpers import get_supported_algorithms
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class ModelSummary:
     """
     Representation of a Model on the Intel® Geti™ platform, containing only the
@@ -45,18 +45,18 @@ class ModelSummary:
     _identifier_fields: ClassVar[List[str]] = ["id", "model_storage_id"]
 
     name: str
-    creation_date: str = attr.ib(converter=str_to_datetime)
+    creation_date: str = attr.field(converter=str_to_datetime)
     score_up_to_date: bool
     size: Optional[int] = None
     version: Optional[int] = None  # 'version' is removed in v1.1
-    score: Optional[float] = attr.ib(default=None)  # 'score' is removed in v1.1
+    score: Optional[float] = attr.field(default=None)  # 'score' is removed in v1.1
     performance: Optional[Performance] = None
-    active_model: bool = attr.ib(default=False)
-    id: Optional[str] = attr.ib(default=None, repr=False)
-    model_storage_id: Optional[str] = attr.ib(default=None, repr=False)
+    active_model: bool = attr.field(default=False)
+    id: Optional[str] = attr.field(default=None, repr=False)
+    model_storage_id: Optional[str] = attr.field(default=None, repr=False)
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True, slots=False)
 class ModelGroup:
     """
     Representation of a ModelGroup on the Intel® Geti™ server. A model group is a
@@ -68,9 +68,9 @@ class ModelGroup:
 
     name: str
     model_template_id: str
-    models: List[ModelSummary] = attr.ib(repr=False)
-    task_id: Optional[str] = attr.ib(default=None)
-    id: Optional[str] = attr.ib(default=None)
+    models: List[ModelSummary] = attr.field(repr=False)
+    task_id: Optional[str] = attr.field(default=None)
+    id: Optional[str] = attr.field(default=None)
 
     def __attrs_post_init__(self) -> None:
         """

--- a/geti_sdk/data_models/model_group.py
+++ b/geti_sdk/data_models/model_group.py
@@ -25,7 +25,7 @@ from geti_sdk.http_session import GetiSession
 from geti_sdk.utils.algorithm_helpers import get_supported_algorithms
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class ModelSummary:
     """
     Representation of a Model on the Intel® Geti™ platform, containing only the
@@ -56,7 +56,7 @@ class ModelSummary:
     model_storage_id: Optional[str] = attr.field(default=None, repr=False)
 
 
-@attr.define(auto_attribs=True, slots=False)
+@attr.define(slots=False)
 class ModelGroup:
     """
     Representation of a ModelGroup on the Intel® Geti™ server. A model group is a

--- a/geti_sdk/data_models/predictions.py
+++ b/geti_sdk/data_models/predictions.py
@@ -27,7 +27,7 @@ from geti_sdk.data_models.utils import deidentify, str_to_annotation_kind
 from geti_sdk.http_session import GetiSession
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class ResultMedium:
     """
     Representation of a single result medium in Intel® Geti™.
@@ -47,8 +47,8 @@ class ResultMedium:
     label_id: Optional[str] = None
     id: Optional[str] = None
     roi: Optional[Dict[str, Any]] = None
-    label_name: Optional[str] = attr.ib(init=False, default=None)
-    data: Optional[bytes] = attr.ib(default=None, repr=False, init=False)
+    label_name: Optional[str] = attr.field(init=False, default=None)
+    data: Optional[bytes] = attr.field(default=None, repr=False, init=False)
 
     def resolve_label_name(self, labels: List[Label]):
         """
@@ -101,7 +101,7 @@ class ResultMedium:
         )
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class Prediction(AnnotationScene):
     """
     Representation of the model predictions for a certain media entity in Intel® Geti™.
@@ -115,12 +115,12 @@ class Prediction(AnnotationScene):
     :var maps: List of additional result media belonging to this prediction
     """
 
-    kind: str = attr.ib(
+    kind: str = attr.field(
         converter=str_to_annotation_kind,
         default=AnnotationKind.PREDICTION,
         kw_only=True,
     )
-    maps: List[ResultMedium] = attr.ib(factory=list, kw_only=True)
+    maps: List[ResultMedium] = attr.field(factory=list, kw_only=True)
 
     def resolve_labels_for_result_media(self, labels: List[Label]) -> None:
         """

--- a/geti_sdk/data_models/predictions.py
+++ b/geti_sdk/data_models/predictions.py
@@ -27,7 +27,7 @@ from geti_sdk.data_models.utils import deidentify, str_to_annotation_kind
 from geti_sdk.http_session import GetiSession
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class ResultMedium:
     """
     Representation of a single result medium in Intel® Geti™.
@@ -101,7 +101,7 @@ class ResultMedium:
         )
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class Prediction(AnnotationScene):
     """
     Representation of the model predictions for a certain media entity in Intel® Geti™.

--- a/geti_sdk/data_models/project.py
+++ b/geti_sdk/data_models/project.py
@@ -29,7 +29,7 @@ from .utils import (
 )
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class Connection:
     """
     Representation of a connection between two tasks in GETi.
@@ -42,7 +42,7 @@ class Connection:
     from_: str
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class Pipeline:
     """
     Representation of a pipeline for a project in GETi.
@@ -141,7 +141,7 @@ class Pipeline:
             task.deidentify()
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class Dataset:
     """
     Representation of a dataset for a project in Intel® Geti™.
@@ -164,7 +164,7 @@ class Dataset:
         deidentify(self)
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class Project:
     """
     Representation of a project in Intel® Geti™.

--- a/geti_sdk/data_models/project.py
+++ b/geti_sdk/data_models/project.py
@@ -29,7 +29,7 @@ from .utils import (
 )
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class Connection:
     """
     Representation of a connection between two tasks in GETi.
@@ -42,7 +42,7 @@ class Connection:
     from_: str
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class Pipeline:
     """
     Representation of a pipeline for a project in GETi.
@@ -141,7 +141,7 @@ class Pipeline:
             task.deidentify()
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class Dataset:
     """
     Representation of a dataset for a project in Intel® Geti™.
@@ -154,7 +154,7 @@ class Dataset:
 
     name: str
     id: Optional[str] = None
-    creation_time: Optional[str] = attr.ib(default=None, converter=str_to_datetime)
+    creation_time: Optional[str] = attr.field(default=None, converter=str_to_datetime)
     use_for_training: Optional[bool] = None
 
     def deidentify(self) -> None:
@@ -164,7 +164,7 @@ class Dataset:
         deidentify(self)
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class Project:
     """
     Representation of a project in Intel® Geti™.
@@ -190,7 +190,7 @@ class Project:
     datasets: List[Dataset]
     score: Optional[float] = None  # 'score' is removed in v1.1
     performance: Optional[Performance] = None
-    creation_time: Optional[str] = attr.ib(default=None, converter=str_to_datetime)
+    creation_time: Optional[str] = attr.field(default=None, converter=str_to_datetime)
     id: Optional[str] = None
     thumbnail: Optional[str] = None
     creator_id: Optional[str] = None

--- a/geti_sdk/data_models/shapes.py
+++ b/geti_sdk/data_models/shapes.py
@@ -39,7 +39,7 @@ N_DIGITS_TO_ROUND_TO = 0
 coordinate_converter = round_to_n_digits(N_DIGITS_TO_ROUND_TO)
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True, slots=False)
 class Shape:
     """
     Representation of a shape in on the Intel® Geti™ platform.
@@ -47,7 +47,7 @@ class Shape:
     :var type: Type of the shape
     """
 
-    type: str = attr.ib(converter=str_to_shape_type)
+    type: str = attr.field(converter=str_to_shape_type)
 
     @abc.abstractmethod
     def to_roi(self) -> "Rectangle":
@@ -119,7 +119,7 @@ class Shape:
         raise NotImplementedError
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class Rectangle(Shape):
     """
     Representation of a Rectangle on the Intel® Geti™ platform, as used in the
@@ -133,11 +133,11 @@ class Rectangle(Shape):
     :var height: Height of the rectangle
     """
 
-    x: int = attr.ib(converter=coordinate_converter)
-    y: int = attr.ib(converter=coordinate_converter)
-    width: int = attr.ib(converter=coordinate_converter)
-    height: int = attr.ib(converter=coordinate_converter)
-    type: str = attr.ib(
+    x: int = attr.field(converter=coordinate_converter)
+    y: int = attr.field(converter=coordinate_converter)
+    width: int = attr.field(converter=coordinate_converter)
+    height: int = attr.field(converter=coordinate_converter)
+    type: str = attr.field(
         converter=str_to_shape_type, default=ShapeType.RECTANGLE, kw_only=True
     )
 
@@ -249,7 +249,7 @@ class Rectangle(Shape):
         return self.y + self.height
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class Ellipse(Shape):
     """
     Representation of an Ellipse on the Intel® Geti™ platform, as used in the
@@ -263,11 +263,11 @@ class Ellipse(Shape):
     :var height: Height of the ellipse
     """
 
-    x: int = attr.ib(converter=coordinate_converter)
-    y: int = attr.ib(converter=coordinate_converter)
-    width: int = attr.ib(converter=coordinate_converter)
-    height: int = attr.ib(converter=coordinate_converter)
-    type: str = attr.ib(
+    x: int = attr.field(converter=coordinate_converter)
+    y: int = attr.field(converter=coordinate_converter)
+    width: int = attr.field(converter=coordinate_converter)
+    height: int = attr.field(converter=coordinate_converter)
+    type: str = attr.field(
         converter=str_to_shape_type, default=ShapeType.ELLIPSE, kw_only=True
     )
 
@@ -364,7 +364,7 @@ class Ellipse(Shape):
         return self.y + self.height
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class Point:
     """
     Representation of a point on a 2D coordinate system. Used to define Polygons on
@@ -376,11 +376,11 @@ class Point:
     :var y: Y coordinate of the point
     """
 
-    x: int = attr.ib(converter=coordinate_converter)
-    y: int = attr.ib(converter=coordinate_converter)
+    x: int = attr.field(converter=coordinate_converter)
+    y: int = attr.field(converter=coordinate_converter)
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class Polygon(Shape):
     """
     Representation of a polygon on the Intel® Geti™ platform, as used in the
@@ -390,7 +390,7 @@ class Polygon(Shape):
     """
 
     points: List[Point]
-    type: str = attr.ib(
+    type: str = attr.field(
         converter=str_to_shape_type, default=ShapeType.POLYGON, kw_only=True
     )
 
@@ -542,7 +542,7 @@ class Polygon(Shape):
         )
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class RotatedRectangle(Shape):
     """
     Representation of a RotatedRectangle on the Intel® Geti™ platform, as used in the
@@ -557,12 +557,12 @@ class RotatedRectangle(Shape):
     :var height: Height of the rectangle
     """
 
-    angle: float = attr.ib(converter=round_to_n_digits(n=4))
-    x: int = attr.ib(converter=coordinate_converter)
-    y: int = attr.ib(converter=coordinate_converter)
-    width: int = attr.ib(converter=coordinate_converter)
-    height: int = attr.ib(converter=coordinate_converter)
-    type: str = attr.ib(
+    angle: float = attr.field(converter=round_to_n_digits(n=4))
+    x: int = attr.field(converter=coordinate_converter)
+    y: int = attr.field(converter=coordinate_converter)
+    width: int = attr.field(converter=coordinate_converter)
+    height: int = attr.field(converter=coordinate_converter)
+    type: str = attr.field(
         converter=str_to_shape_type, default=ShapeType.ROTATED_RECTANGLE, kw_only=True
     )
 

--- a/geti_sdk/data_models/shapes.py
+++ b/geti_sdk/data_models/shapes.py
@@ -39,7 +39,7 @@ N_DIGITS_TO_ROUND_TO = 0
 coordinate_converter = round_to_n_digits(N_DIGITS_TO_ROUND_TO)
 
 
-@attr.define(auto_attribs=True, slots=False)
+@attr.define(slots=False)
 class Shape:
     """
     Representation of a shape in on the Intel® Geti™ platform.
@@ -119,7 +119,7 @@ class Shape:
         raise NotImplementedError
 
 
-@attr.define(auto_attribs=True)
+@attr.define(slots=False)
 class Rectangle(Shape):
     """
     Representation of a Rectangle on the Intel® Geti™ platform, as used in the
@@ -249,7 +249,7 @@ class Rectangle(Shape):
         return self.y + self.height
 
 
-@attr.define(auto_attribs=True)
+@attr.define(slots=False)
 class Ellipse(Shape):
     """
     Representation of an Ellipse on the Intel® Geti™ platform, as used in the
@@ -364,7 +364,7 @@ class Ellipse(Shape):
         return self.y + self.height
 
 
-@attr.define(auto_attribs=True)
+@attr.define(slots=False)
 class Point:
     """
     Representation of a point on a 2D coordinate system. Used to define Polygons on
@@ -380,7 +380,7 @@ class Point:
     y: int = attr.field(converter=coordinate_converter)
 
 
-@attr.define(auto_attribs=True)
+@attr.define(slots=False)
 class Polygon(Shape):
     """
     Representation of a polygon on the Intel® Geti™ platform, as used in the
@@ -542,7 +542,7 @@ class Polygon(Shape):
         )
 
 
-@attr.define(auto_attribs=True)
+@attr.define(slots=False)
 class RotatedRectangle(Shape):
     """
     Representation of a RotatedRectangle on the Intel® Geti™ platform, as used in the

--- a/geti_sdk/data_models/status.py
+++ b/geti_sdk/data_models/status.py
@@ -19,7 +19,7 @@ import attr
 from geti_sdk.data_models.performance import Performance
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class StatusSummary:
     """
     Summary of the status of a project or task on the GETi cluster.
@@ -46,7 +46,7 @@ class StatusSummary:
         return cls(**status_dict)
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class LabelAnnotationRequirements:
     """
     Detailed information regarding the required number of annotations for a
@@ -64,7 +64,7 @@ class LabelAnnotationRequirements:
     value: int
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class AnnotationRequirements:
     """
     Container holding the required number of annotations before auto-training can be
@@ -78,7 +78,7 @@ class AnnotationRequirements:
     value: int
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class TaskStatus:
     """
     Status of a single task in GETi.
@@ -100,7 +100,7 @@ class TaskStatus:
     title: str
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class ProjectStatus:
     """
     Status of a project in GETi.

--- a/geti_sdk/data_models/status.py
+++ b/geti_sdk/data_models/status.py
@@ -19,7 +19,7 @@ import attr
 from geti_sdk.data_models.performance import Performance
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class StatusSummary:
     """
     Summary of the status of a project or task on the GETi cluster.
@@ -46,7 +46,7 @@ class StatusSummary:
         return cls(**status_dict)
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class LabelAnnotationRequirements:
     """
     Detailed information regarding the required number of annotations for a
@@ -64,7 +64,7 @@ class LabelAnnotationRequirements:
     value: int
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class AnnotationRequirements:
     """
     Container holding the required number of annotations before auto-training can be
@@ -78,7 +78,7 @@ class AnnotationRequirements:
     value: int
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class TaskStatus:
     """
     Status of a single task in GETi.
@@ -100,7 +100,7 @@ class TaskStatus:
     title: str
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class ProjectStatus:
     """
     Status of a project in GETi.

--- a/geti_sdk/data_models/task.py
+++ b/geti_sdk/data_models/task.py
@@ -33,7 +33,7 @@ from geti_sdk.data_models.utils import (
 )
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class Task:
     """
     Representation of a Task in GETi.
@@ -48,7 +48,7 @@ class Task:
     _identifier_fields: ClassVar[List[str]] = ["id", "label_schema_id"]
 
     title: str
-    task_type: str = attr.ib(converter=str_to_task_type)
+    task_type: str = attr.field(converter=str_to_task_type)
     labels: Optional[List[Label]] = None
     label_schema_id: Optional[str] = None
     id: Optional[str] = None

--- a/geti_sdk/data_models/task.py
+++ b/geti_sdk/data_models/task.py
@@ -33,7 +33,7 @@ from geti_sdk.data_models.utils import (
 )
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class Task:
     """
     Representation of a Task in GETi.

--- a/geti_sdk/data_models/task_annotation_state.py
+++ b/geti_sdk/data_models/task_annotation_state.py
@@ -18,7 +18,7 @@ from geti_sdk.data_models.enums import AnnotationState
 from geti_sdk.data_models.utils import str_to_enum_converter_by_name_or_value
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class TaskAnnotationState:
     """
     Representation of the state of an annotation for a particular task in an
@@ -26,6 +26,6 @@ class TaskAnnotationState:
     """
 
     task_id: str
-    state: str = attr.ib(
+    state: str = attr.field(
         converter=str_to_enum_converter_by_name_or_value(AnnotationState)
     )

--- a/geti_sdk/data_models/task_annotation_state.py
+++ b/geti_sdk/data_models/task_annotation_state.py
@@ -18,7 +18,7 @@ from geti_sdk.data_models.enums import AnnotationState
 from geti_sdk.data_models.utils import str_to_enum_converter_by_name_or_value
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class TaskAnnotationState:
     """
     Representation of the state of an annotation for a particular task in an

--- a/geti_sdk/data_models/utils.py
+++ b/geti_sdk/data_models/utils.py
@@ -27,7 +27,7 @@ EnumType = TypeVar("EnumType", bound=Enum)
 
 def deidentify(instance: Any):
     """
-    Set all identifier fields of an instance of an attr.s decorated class within the
+    Set all identifier fields of an instance of an attr.define decorated class within the
     GETi REST DataModels to None.
 
     :param instance: Object to deidentify
@@ -211,7 +211,7 @@ def str_to_datetime(datetime_str: Optional[Union[str, datetime]]) -> Optional[da
 
 def attr_value_serializer(instance, field, value):
     """
-    Convert a value in an attr.s decorated class to string representation, used
+    Convert a value in an attr.define decorated class to string representation, used
     while converting the attrs object to a dictionary.
 
     Converts Enums and datetime objects to string representation

--- a/geti_sdk/deployment/data_models/intermediate_inference_result.py
+++ b/geti_sdk/deployment/data_models/intermediate_inference_result.py
@@ -22,7 +22,7 @@ from geti_sdk.data_models import Annotation, Label, Prediction
 from .region_of_interest import ROI
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class IntermediateInferenceResult:
     """
     Inference results for intermediate tasks in the pipeline

--- a/geti_sdk/deployment/data_models/intermediate_inference_result.py
+++ b/geti_sdk/deployment/data_models/intermediate_inference_result.py
@@ -22,7 +22,7 @@ from geti_sdk.data_models import Annotation, Label, Prediction
 from .region_of_interest import ROI
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class IntermediateInferenceResult:
     """
     Inference results for intermediate tasks in the pipeline

--- a/geti_sdk/deployment/data_models/region_of_interest.py
+++ b/geti_sdk/deployment/data_models/region_of_interest.py
@@ -18,7 +18,7 @@ from geti_sdk.data_models import Annotation
 from geti_sdk.data_models.shapes import Rectangle, Shape
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class ROI(Annotation):
     """
     A region of interest for a given image. ROIs are generated for
@@ -26,8 +26,8 @@ class ROI(Annotation):
     labels (for instance a detection or segmentation task).
     """
 
-    shape: Rectangle = attr.ib(kw_only=True)
-    original_shape: Shape = attr.ib(kw_only=True)
+    shape: Rectangle = attr.field(kw_only=True)
+    original_shape: Shape = attr.field(kw_only=True)
 
     @classmethod
     def from_annotation(cls, annotation: Annotation) -> "ROI":

--- a/geti_sdk/deployment/data_models/region_of_interest.py
+++ b/geti_sdk/deployment/data_models/region_of_interest.py
@@ -18,7 +18,7 @@ from geti_sdk.data_models import Annotation
 from geti_sdk.data_models.shapes import Rectangle, Shape
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class ROI(Annotation):
     """
     A region of interest for a given image. ROIs are generated for

--- a/geti_sdk/deployment/deployed_model.py
+++ b/geti_sdk/deployment/deployed_model.py
@@ -43,14 +43,14 @@ LABEL_GROUPS_KEY = "label_groups"
 ALL_LABELS_KEY = "all_labels"
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True)
 class DeployedModel(OptimizedModel):
     """
     Representation of an Intel® Geti™ model that has been deployed for inference. It
     can be loaded onto a device to generate predictions.
     """
 
-    hyper_parameters: Optional[TaskConfiguration] = attr.ib(
+    hyper_parameters: Optional[TaskConfiguration] = attr.field(
         kw_only=True, repr=False, default=None
     )
 

--- a/geti_sdk/deployment/deployed_model.py
+++ b/geti_sdk/deployment/deployed_model.py
@@ -43,7 +43,7 @@ LABEL_GROUPS_KEY = "label_groups"
 ALL_LABELS_KEY = "all_labels"
 
 
-@attr.define(auto_attribs=True)
+@attr.define
 class DeployedModel(OptimizedModel):
     """
     Representation of an Intel® Geti™ model that has been deployed for inference. It

--- a/geti_sdk/deployment/deployment.py
+++ b/geti_sdk/deployment/deployment.py
@@ -34,7 +34,7 @@ from geti_sdk.deployment.deployed_model import DeployedModel
 from geti_sdk.rest_converters import ProjectRESTConverter
 
 
-@attr.define(auto_attribs=True, slots=False)
+@attr.define(slots=False)
 class Deployment:
     """
     Representation of a deployed Intel® Geti™ project that can be used to run

--- a/geti_sdk/deployment/deployment.py
+++ b/geti_sdk/deployment/deployment.py
@@ -34,7 +34,7 @@ from geti_sdk.deployment.deployed_model import DeployedModel
 from geti_sdk.rest_converters import ProjectRESTConverter
 
 
-@attr.s(auto_attribs=True)
+@attr.define(auto_attribs=True, slots=False)
 class Deployment:
     """
     Representation of a deployed Intel® Geti™ project that can be used to run


### PR DESCRIPTION
Previously we were using the legacy attrs API where classes were decorated with `attr.s()` and fields were decorated with `attr.ib()`. Now the classes and fields are decorated with `define()' and `field()`.

