### PR TITLE
Minor changes for backward compatibility with SCv1.1

### DIFF
--- a/geti_sdk/data_models/status.py
+++ b/geti_sdk/data_models/status.py
@@ -121,6 +121,7 @@ class ProjectStatus:
     status: StatusSummary
     tasks: List[TaskStatus]
     project_performance: Optional[Performance] = None
+    project_score: Optional[float] = None  # Deprecated in Geti 1.0, to be removed
     n_running_jobs: Optional[int] = None
     n_running_jobs_project: Optional[int] = None
 

--- a/geti_sdk/rest_clients/model_client.py
+++ b/geti_sdk/rest_clients/model_client.py
@@ -56,7 +56,12 @@ class ModelClient:
         """
         response = self.session.get_rest_response(url=self.base_url, method="GET")
         if self.session.version.is_sc_1_1 or self.session.version.is_sc_mvp:
-            response_array = response["items"]
+            # The API is not fully consistent here, depending on exact release.
+            # Response may either be a dict or a list
+            try:
+                response_array = response["items"]
+            except TypeError:
+                response_array = response
         else:
             response_array = response["model_groups"]
         model_groups = [


### PR DESCRIPTION
- Restore deprecated `project_score` field
- Handle list response in get_all_model_groups endpoint