### PR TITLE
Validate media filename upon download

### DIFF
--- a/geti_sdk/data_models/containers/media_list.py
+++ b/geti_sdk/data_models/containers/media_list.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import os
 from collections import UserList
 from typing import Any, Dict, Generic, List, Type, TypeVar
 
@@ -100,5 +101,5 @@ class MediaList(UserList, Generic[MediaTypeVar]):
         Return True if the media list contains at least two items that have the same
         filename, False otherwise.
         """
-        filenames = self.names
+        filenames = [os.path.basename(name) for name in self.names]
         return len(set(filenames)) != len(filenames)

--- a/geti_sdk/rest_clients/annotation_clients/base_annotation_client.py
+++ b/geti_sdk/rest_clients/annotation_clients/base_annotation_client.py
@@ -376,19 +376,21 @@ class BaseAnnotationClient:
                 continue
             export_data = AnnotationRESTConverter.to_dict(annotation_scene)
 
-            filename = media_item.name + ".json"
+            base_media_item_name = os.path.basename(media_item.name)
+            filename = base_media_item_name + ".json"
             if append_media_uid:
                 if isinstance(media_item, Image):
-                    filename = f"{media_item.name}_{media_item.id}.json"
+                    filename = f"{base_media_item_name}_{media_item.id}.json"
                 elif isinstance(media_item, VideoFrame):
                     if media_item.video_name is not None:
+                        base_video_name = os.path.basename(media_item.video_name)
                         filename = (
-                            f"{media_item.video_name}_"
+                            f"{base_video_name}_"
                             f"{media_item.media_information.video_id}_frame_"
                             f"{media_item.media_information.frame_index}.json"
                         )
                     else:
-                        video_name = media_item.name.split("_frame_")[0]
+                        video_name = base_media_item_name.split("_frame_")[0]
                         filename = (
                             f"{video_name}_"
                             f"{media_item.media_information.video_id}_frame_"
@@ -401,7 +403,6 @@ class BaseAnnotationClient:
 
             annotation_path = os.path.join(path_to_annotations_folder, filename)
 
-            os.makedirs(os.path.dirname(annotation_path), exist_ok=True)
             with open(annotation_path, "w") as f:
                 json.dump(export_data, f, indent=4)
             download_count += 1

--- a/geti_sdk/rest_clients/media_client/media_client.py
+++ b/geti_sdk/rest_clients/media_client/media_client.py
@@ -294,7 +294,7 @@ class BaseMediaClient(Generic[MediaTypeVar]):
                 uid_string = f"_{media_item.id}"
             media_filepath = os.path.join(
                 path_to_media_folder,
-                media_item.name
+                os.path.basename(media_item.name)
                 + uid_string
                 + MEDIA_DOWNLOAD_FORMAT_MAPPING[self._MEDIA_TYPE],
             )
@@ -305,7 +305,6 @@ class BaseMediaClient(Generic[MediaTypeVar]):
                 url=media_item.download_url, method="GET", contenttype="jpeg"
             )
 
-            os.makedirs(os.path.dirname(media_filepath), exist_ok=True)
             with open(media_filepath, "wb") as f:
                 f.write(response.content)
             if isinstance(media_item, (Image, VideoFrame)):


### PR DESCRIPTION
We make sure that there are no folder separators included in the name. If there are, this would create a nested folder hierarchy that would break uploading of the project