### PR TITLE
Fix anomaly classification deployment

### DIFF
--- a/geti_sdk/deployment/deployment.py
+++ b/geti_sdk/deployment/deployment.py
@@ -148,6 +148,15 @@ class Deployment:
         for model, task in zip(self.models, self.project.get_trainable_tasks()):
             model.load_inference_model(device=device)
 
+            # This is a workaround for a bug in the label schema for anomaly tasks
+            if task.type.is_anomaly:
+                # For some reason the `is_anomaly` flag is not set correctly in the
+                # ote_label_schema, which will break loading the prediction converter.
+                # We set the flag here
+                for label in model.ote_label_schema.get_labels(include_empty=True):
+                    if label.name == "Anomalous":
+                        label.is_anomalous = True
+
             inference_converter = create_converter(
                 converter_type=task.type.to_ote_domain(), labels=model.ote_label_schema
             )

--- a/tests/nightly/demos/test_demo_projects.py
+++ b/tests/nightly/demos/test_demo_projects.py
@@ -18,11 +18,7 @@ import pytest
 
 from geti_sdk import Geti
 from geti_sdk.data_models import Project
-from geti_sdk.demos import (
-    ensure_trained_anomaly_project,
-    ensure_trained_example_project,
-    get_coco_dataset,
-)
+from geti_sdk.demos import ensure_trained_example_project, get_coco_dataset
 from geti_sdk.demos.data_helpers.anomaly_helpers import get_mvtec_dataset, is_ad_dataset
 from geti_sdk.demos.data_helpers.coco_helpers import (
     COCOSubset,
@@ -128,31 +124,6 @@ class TestDemoProjects:
             geti=fxt_geti_no_vcr, project=fxt_detection_demo_project
         )
 
-        assert prediction_client.ready_to_predict
-
-    def test_ensure_trained_anomaly_project(
-        self, fxt_geti_no_vcr: Geti, fxt_project_client_no_vcr: ProjectClient
-    ):
-        """
-        Test the `ensure_trained_anomaly_project` method
-        """
-        project_name = f"{PROJECT_PREFIX}_ensure_trained_anomaly_project"
-        if fxt_project_client_no_vcr.get_project_by_name(project_name) is not None:
-            force_delete_project(
-                project_name=project_name, project_client=fxt_project_client_no_vcr
-            )
-        assert project_name not in [
-            project.name for project in fxt_project_client_no_vcr.get_all_projects()
-        ]
-
-        project = ensure_trained_anomaly_project(
-            geti=fxt_geti_no_vcr, project_name=project_name
-        )
-        prediction_client = PredictionClient(
-            session=fxt_geti_no_vcr.session,
-            workspace_id=fxt_geti_no_vcr.workspace_id,
-            project=project,
-        )
         assert prediction_client.ready_to_predict
 
     def test_ensure_trained_example_project(

--- a/tests/nightly/test_anomaly_classification.py
+++ b/tests/nightly/test_anomaly_classification.py
@@ -1,0 +1,71 @@
+from geti_sdk import Geti
+from geti_sdk.demos import ensure_trained_anomaly_project
+from geti_sdk.rest_clients import ProjectClient
+from tests.helpers import ProjectService, force_delete_project
+from tests.helpers.constants import PROJECT_PREFIX
+from tests.nightly.test_nightly_project import TestNightlyProject
+
+
+class TestAnomalyClassification(TestNightlyProject):
+    PROJECT_TYPE = "anomaly_classification"
+    __test__ = True
+
+    def test_project_setup(
+        self,
+        fxt_project_service_no_vcr: ProjectService,
+        fxt_geti_no_vcr: Geti,
+        fxt_project_client_no_vcr: ProjectClient,
+    ):
+        """
+        Test the `ensure_trained_anomaly_project` method
+        """
+        project_name = f"{PROJECT_PREFIX}_ensure_trained_anomaly_project"
+        if fxt_project_client_no_vcr.get_project_by_name(project_name) is not None:
+            force_delete_project(
+                project_name=project_name, project_client=fxt_project_client_no_vcr
+            )
+        assert project_name not in [
+            project.name for project in fxt_project_client_no_vcr.get_all_projects()
+        ]
+
+        project = ensure_trained_anomaly_project(
+            geti=fxt_geti_no_vcr, project_name=project_name
+        )
+        fxt_project_service_no_vcr._project = project
+
+        assert fxt_project_service_no_vcr.prediction_client.ready_to_predict
+
+    def test_monitor_jobs(self, fxt_project_service_no_vcr: ProjectService):
+        """
+        For anomaly classification projects, the training is run in the project_setup
+        phase. No need to monitor jobs.
+        """
+        pass
+
+    def test_upload_and_predict_image(
+        self,
+        fxt_project_service_no_vcr: ProjectService,
+        fxt_image_path: str,
+        fxt_geti_no_vcr: Geti,
+    ):
+        super().test_upload_and_predict_image(
+            fxt_project_service_no_vcr, fxt_image_path, fxt_geti_no_vcr
+        )
+
+    def test_deployment(
+        self,
+        fxt_project_service_no_vcr: ProjectService,
+        fxt_geti_no_vcr: Geti,
+        fxt_temp_directory: str,
+        fxt_image_path: str,
+        fxt_image_path_complex: str,
+        fxt_artifact_directory: str,
+    ):
+        super().test_deployment(
+            fxt_project_service_no_vcr,
+            fxt_geti_no_vcr,
+            fxt_temp_directory,
+            fxt_image_path,
+            fxt_image_path_complex,
+            fxt_artifact_directory,
+        )


### PR DESCRIPTION
The `Anomalous` label was not recognized as such correctly in the deployment for anomaly models. This PR introduces a workaround that fixes that, upon loading the inference models for anomaly type tasks.