### PR TITLE
Enable SSL certificate validation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,21 @@ Instantiating the `Geti` class will establish the connection and perform authent
   )
 
   ```
-  Here, `"dummy_user"` and `"dummy_password"` should be replaced by your username and password for the Geti server.
+  Here, `"dummy_user"` and `"dummy_password"` should be replaced by your username and
+  password for the Geti server.
 
+
+- **SSL certificate validation**
+
+  By default, the SDK verifies the SSL certificate of your server before establishing
+  a connection over HTTPS. If the certificate can't be validated, this will results in
+  an error and the SDK will not be able to connect to the server.
+
+  However, this may not be appropriate or desirable in all cases, for instance if your
+  Geti server does not have a certificate because you are running it in a private
+  network environment. In that case, certificate validation can be disabled by passing
+  `verify_certificate=False` to the `Geti` constructor. Please only disable certificate
+  validation in a secure environment!
 
 #### Downloading and uploading projects
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -45,6 +45,18 @@ the examples, simply:
 >
 > In case both a TOKEN and USERNAME/PASSWORD variables are provided, the SDK
 > will default to using the TOKEN since this method is considered more secure.
+> #### SSL Certificate verification
+> By default, the SDK verifies the SSL certificate of your server before establishing
+> a connection over HTTPS. If the certificate can't be validated, this will results in
+> an error and the SDK will not be able to connect to the server.
+>
+> However, this may not be appropriate or desirable in all cases, for instance if your
+> Geti server does not have a certificate because you are running it in a private
+> network environment. In that case, certificate validation can be disabled by adding
+> the following variable to the `.env` file:
+> ```shell
+> VERIFY_CERT=0
+> ```
 
 ## Creating a project from an existing dataset
 #### COCO/Datumaro examples

--- a/examples/create_coco_project_single_task.py
+++ b/examples/create_coco_project_single_task.py
@@ -4,14 +4,14 @@ from geti_sdk.demos import get_coco_dataset
 from geti_sdk.utils import get_server_details_from_env
 
 if __name__ == "__main__":
-    # Get credentials from .env file
-    hostname, authentication = get_server_details_from_env()
+    # Get the server configuration from .env file
+    server_config = get_server_details_from_env()
 
     # --------------------------------------------------
     # Configuration section
     # --------------------------------------------------
-    # Set up the Geti instance with server hostname and authentication details
-    geti = Geti(host=hostname, **authentication)
+    # Set up the Geti instance with the server configuration details
+    geti = Geti(server_config=server_config)
 
     # Dataset configuration
     NUMBER_OF_IMAGES_TO_UPLOAD = 75

--- a/examples/create_coco_project_task_chain.py
+++ b/examples/create_coco_project_task_chain.py
@@ -4,14 +4,14 @@ from geti_sdk.demos import get_coco_dataset
 from geti_sdk.utils import get_server_details_from_env, get_task_types_by_project_type
 
 if __name__ == "__main__":
-    # Get credentials from .env file
-    hostname, authentication = get_server_details_from_env()
+    # Get the server configuration from .env file
+    server_config = get_server_details_from_env()
 
     # --------------------------------------------------
     # Configuration section
     # --------------------------------------------------
-    # Set up the Geti instance with server hostname and authentication details
-    geti = Geti(host=hostname, **authentication)
+    # Set up the Geti instance with the server configuration details
+    geti = Geti(server_config=server_config)
 
     # Dataset configuration
     NUMBER_OF_IMAGES_TO_UPLOAD = 75

--- a/examples/create_demo_projects.py
+++ b/examples/create_demo_projects.py
@@ -11,14 +11,14 @@ from geti_sdk.demos import (
 from geti_sdk.utils import get_server_details_from_env
 
 if __name__ == "__main__":
-    # Get credentials from .env file
-    hostname, authentication = get_server_details_from_env()
+    # Get the server configuration from .env file
+    server_config = get_server_details_from_env()
 
     # --------------------------------------------------
     # Configuration section
     # --------------------------------------------------
-    # Set up the Geti instance with server hostname and authentication details
-    geti = Geti(host=hostname, **authentication)
+    # Set up the Geti instance with the server configuration details
+    geti = Geti(server_config=server_config)
 
     # Dataset configuration
     NUMBER_OF_IMAGES_TO_UPLOAD = 100

--- a/examples/upload_and_predict_from_numpy.py
+++ b/examples/upload_and_predict_from_numpy.py
@@ -26,14 +26,14 @@ def rotate_image(image: np.ndarray, angle: float) -> np.ndarray:
 
 
 if __name__ == "__main__":
-    # Get credentials from .env file
-    hostname, authentication = get_server_details_from_env()
+    # Get the server configuration from .env file
+    server_config = get_server_details_from_env()
 
     # --------------------------------------------------
     # Configuration section
     # --------------------------------------------------
-    # Set up the Geti instance with server hostname and authentication details
-    geti = Geti(host=hostname, **authentication)
+    # Set up the Geti instance with the server configuration details
+    geti = Geti(server_config=server_config)
 
     # `PROJECT_NAME` is the name of the project to which the media should be uploaded,
     # and from which predictions can be requested. A project with this name should

--- a/examples/upload_and_predict_media_from_folder.py
+++ b/examples/upload_and_predict_media_from_folder.py
@@ -5,14 +5,14 @@ from geti_sdk.demos import EXAMPLE_IMAGE_PATH, ensure_trained_example_project
 from geti_sdk.utils import get_server_details_from_env
 
 if __name__ == "__main__":
-    # Get credentials from .env file
-    hostname, authentication = get_server_details_from_env()
+    # Get the server configuration from .env file
+    server_config = get_server_details_from_env()
 
     # --------------------------------------------------
     # Configuration section
     # --------------------------------------------------
-    # Set up the Geti instance with server hostname and authentication details
-    geti = Geti(host=hostname, **authentication)
+    # Set up the Geti instance with the server configuration details
+    geti = Geti(server_config=server_config)
 
     # `FOLDER_WITH_MEDIA` is the path to the directory with images and videos that
     # should be uploaded to the GETi cluster

--- a/geti_sdk/http_session/geti_session.py
+++ b/geti_sdk/http_session/geti_session.py
@@ -165,6 +165,12 @@ class GetiSession(requests.Session):
         """
         try:
             login_path = self._get_initial_login_url()
+        except requests.exceptions.SSLError as error:
+            raise requests.exceptions.SSLError(
+                f"Connection to Intel® Geti™ server at '{self.config.host}' failed, "
+                f"the server address can be resolved but the SSL certificate could not "
+                f"be verified. \n Full error description: {error.args[-1]}"
+            )
         except requests.exceptions.ConnectionError as error:
             if "dummy" in self.config.password or "dummy" in self.config.username:
                 raise ValueError(
@@ -243,7 +249,14 @@ class GetiSession(requests.Session):
         if not self.use_token:
             request_params.update({"cookies": self._cookies})
 
-        response = self.request(**request_params, **self._proxies)
+        try:
+            response = self.request(**request_params, **self._proxies)
+        except requests.exceptions.SSLError as error:
+            raise requests.exceptions.SSLError(
+                f"Connection to Intel® Geti™ server at '{self.config.host}' failed, "
+                f"the server address can be resolved but the SSL certificate could not "
+                f"be verified. \n Full error description: {error.args[-1]}"
+            )
 
         if (
             response.status_code not in SUCCESS_STATUS_CODES

--- a/geti_sdk/http_session/server_config.py
+++ b/geti_sdk/http_session/server_config.py
@@ -122,7 +122,7 @@ class ServerCredentialConfig(ServerConfig):
     password: str
 
 
-@attrs.define
+@attrs.define(slots=False)
 class ServerTokenConfig(ServerConfig):
     """
     Configuration for an Intel® Geti™ server that uses a personal access token

--- a/geti_sdk/utils/credentials_helpers.py
+++ b/geti_sdk/utils/credentials_helpers.py
@@ -12,14 +12,46 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 import os
-from typing import Dict, Tuple
+from typing import Optional, Union
 
 from dotenv import dotenv_values
+
+from geti_sdk.http_session.server_config import (
+    ServerCredentialConfig,
+    ServerTokenConfig,
+)
+
+
+def convert_boolean_env_variable(
+    value: Optional[str], default_value: bool = False
+) -> bool:
+    """
+    Convert a string that was extracted from environment variables to a
+    boolean.
+
+    Strings like 'True', 'true', 't', '1', 'T' are accepted and converted to True
+    Strings like 'False', 'false', 'f', '0', 'F', are accepted and converted to False
+    Other strings are rejected, a ValueError will be raised in that case
+
+    :param value: string to convert to boolean
+    :param default_value: Default value to return, will be returned in case `value` is
+        None
+    :return: Boolean corresponding to the input `value`
+    """
+    true_strings = ("true", "1", "t")
+    false_strings = ("false", "0", "f")
+
+    if value is None:
+        return default_value
+
+    if value.lower() not in true_strings + false_strings:
+        raise ValueError(f"Invalid value `{value}` for boolean variable")
+    return value in true_strings
 
 
 def get_server_details_from_env(
     env_file_path: str = ".env", use_global_variables: bool = False
-) -> Tuple[str, Dict[str, str]]:
+) -> Union[ServerTokenConfig, ServerCredentialConfig]:
     """
     Retrieve the server information (hostname and authentication details) from
     environment variables.
@@ -29,14 +61,20 @@ def get_server_details_from_env(
     different file, simply specify the path to the file in `env_file_path`. The
     following variables are relevant:
 
-        HOST     -> hostname or ip address of the Geti server
-        TOKEN    -> Personal Access Token that can be used for authorization
+        HOST        -> hostname or ip address of the Geti server
+
+        TOKEN       -> Personal Access Token that can be used for authorization
+
+        VERIFY_CERT -> boolean, pass 1 or True to verify
+
 
     In addition, authentication via credentials is also supported. In that case, the
     following variables should be provided:
 
         USERNAME -> username to log in to the Geti server
+
         PASSWORD -> password for logging in to the Geti server
+
 
     If both TOKEN, USERNAME and PASSWORD are provided, the method will use the preferred
     token authorization.
@@ -49,17 +87,15 @@ def get_server_details_from_env(
     :param env_file_path: Path to the file containing the server details
     :param use_global_variables: If set to True, the method will not read the server
         details from a file but will use environment variables instead
-    :return: Tuple consisting of:
-      - string holding the hostname or ip address of the server
-      - Dictionary containing the authentication information. This can either contain
-          the personal access token or the username/password to log in to the Geti
-          server.
+    :return: A ServerConfig instance that contains the details of the Geti server
+        specified in the environment
     """
     if use_global_variables:
         host_key = "GETI_HOST"
         token_key = "GETI_TOKEN"
         username_key = "GETI_USERNAME"
         password_key = "GETI_PASSWORD"
+        cert_key = "GETI_VERIFY_CERT"
 
         retrieval_func = os.environ.get
         env_name = "environment variables"
@@ -68,6 +104,7 @@ def get_server_details_from_env(
         token_key = "TOKEN"
         username_key = "USERNAME"
         password_key = "PASSWORD"
+        cert_key = "VERIFY_CERT"
 
         env_variables = dotenv_values(dotenv_path=env_file_path)
         if not env_variables:
@@ -78,6 +115,7 @@ def get_server_details_from_env(
         retrieval_func = env_variables.get
         env_name = "environment file"
 
+    # Extract hostname
     hostname = retrieval_func(host_key, None)
     if hostname is None:
         raise ValueError(
@@ -85,6 +123,12 @@ def get_server_details_from_env(
             f"that the variable {host_key} is defined."
         )
 
+    # Extract certificate validation. Defaults to True
+    verify_certificate = convert_boolean_env_variable(
+        value=retrieval_func(cert_key, None), default_value=True
+    )
+
+    # Extract token/credentials
     token = retrieval_func(token_key, None)
     if token is None:
         user = retrieval_func(username_key, None)
@@ -95,7 +139,14 @@ def get_server_details_from_env(
                 f"the {env_name}. Please make sure that either '{token_key}' or "
                 f"'{username_key}' and '{password_key}' is defined in the environment."
             )
-        authentication_dict = {"username": user, "password": password}
+        server_config = ServerCredentialConfig(
+            host=hostname,
+            username=user,
+            password=password,
+            has_valid_certificate=verify_certificate,
+        )
     else:
-        authentication_dict = {"token": token}
-    return hostname, authentication_dict
+        server_config = ServerTokenConfig(
+            host=hostname, token=token, has_valid_certificate=verify_certificate
+        )
+    return server_config

--- a/notebooks/001_create_project.ipynb
+++ b/notebooks/001_create_project.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "from geti_sdk.utils import get_server_details_from_env\n",
     "\n",
-    "hostname, authentication_info = get_server_details_from_env()"
+    "geti_server_configuration = get_server_details_from_env()"
    ]
   },
   {
@@ -41,7 +41,7 @@
    "source": [
     "from geti_sdk import Geti\n",
     "\n",
-    "geti = Geti(host=hostname, **authentication_info)"
+    "geti = Geti(server_config=geti_server_configuration)"
    ]
   },
   {

--- a/notebooks/002_create_project_from_dataset.ipynb
+++ b/notebooks/002_create_project_from_dataset.ipynb
@@ -27,20 +27,24 @@
    "source": [
     "from geti_sdk.utils import get_server_details_from_env\n",
     "\n",
-    "hostname, authentication_info = get_server_details_from_env()"
+    "geti_server_configuration = get_server_details_from_env()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adc758e8-3ea7-4e47-b97c-317b35f4f59f",
-   "metadata": {},
    "outputs": [],
    "source": [
     "from geti_sdk import Geti\n",
     "\n",
-    "geti = Geti(host=hostname, **authentication_info)"
-   ]
+    "geti = Geti(server_config=geti_server_configuration)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",

--- a/notebooks/003_upload_and_predict_image.ipynb
+++ b/notebooks/003_upload_and_predict_image.ipynb
@@ -25,9 +25,9 @@
     "from geti_sdk import Geti\n",
     "from geti_sdk.utils import get_server_details_from_env\n",
     "\n",
-    "hostname, authentication_info = get_server_details_from_env()\n",
+    "geti_server_configuration = get_server_details_from_env()\n",
     "\n",
-    "geti = Geti(host=hostname, **authentication_info)"
+    "geti = Geti(server_config=geti_server_configuration)"
    ]
   },
   {

--- a/notebooks/004_create_pipeline_project_from_dataset.ipynb
+++ b/notebooks/004_create_pipeline_project_from_dataset.ipynb
@@ -18,14 +18,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# As usual, we will connect to the platform first, using the server details from the .env file\n",
+    "# As usual we will connect to the platform first, using the server details from the .env file\n",
     "\n",
     "from geti_sdk import Geti\n",
     "from geti_sdk.utils import get_server_details_from_env\n",
     "\n",
-    "hostname, authentication_info = get_server_details_from_env()\n",
+    "geti_server_configuration = get_server_details_from_env()\n",
     "\n",
-    "geti = Geti(host=hostname, **authentication_info)"
+    "geti = Geti(server_config=geti_server_configuration)"
    ]
   },
   {

--- a/notebooks/005_modify_image.ipynb
+++ b/notebooks/005_modify_image.ipynb
@@ -18,15 +18,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# As usual, we will connect to the platform first, using the server details from the .env file. We will also create a ProjectClient for the server\n",
+    "# As usual we will connect to the platform first, using the server details from the .env file\n",
     "\n",
     "from geti_sdk import Geti\n",
     "from geti_sdk.rest_clients import ProjectClient\n",
     "from geti_sdk.utils import get_server_details_from_env\n",
     "\n",
-    "hostname, authentication_info = get_server_details_from_env()\n",
+    "geti_server_configuration = get_server_details_from_env()\n",
     "\n",
-    "geti = Geti(host=hostname, **authentication_info)\n",
+    "geti = Geti(server_config=geti_server_configuration)\n",
     "\n",
     "project_client = ProjectClient(session=geti.session, workspace_id=geti.workspace_id)"
    ]

--- a/notebooks/006_reconfigure_task.ipynb
+++ b/notebooks/006_reconfigure_task.ipynb
@@ -16,15 +16,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# As usual, we will connect to the platform first, using the server details from the .env file. We will also create a ProjectClient for the server\n",
+    "# As usual we will connect to the platform first, using the server details from the .env file. We will also create a ProjectClient for the server\n",
     "\n",
     "from geti_sdk import Geti\n",
     "from geti_sdk.rest_clients import ProjectClient\n",
     "from geti_sdk.utils import get_server_details_from_env\n",
     "\n",
-    "hostname, authentication_info = get_server_details_from_env()\n",
+    "geti_server_configuration = get_server_details_from_env()\n",
     "\n",
-    "geti = Geti(host=hostname, **authentication_info)\n",
+    "geti = Geti(server_config=geti_server_configuration)\n",
     "\n",
     "project_client = ProjectClient(session=geti.session, workspace_id=geti.workspace_id)"
    ]

--- a/notebooks/007_train_project.ipynb
+++ b/notebooks/007_train_project.ipynb
@@ -16,14 +16,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# As usual, we will connect to the platform first, using the server details from the .env file\n",
+    "# As usual we will connect to the platform first, using the server details from the .env file\n",
     "\n",
     "from geti_sdk import Geti\n",
     "from geti_sdk.utils import get_server_details_from_env\n",
     "\n",
-    "hostname, authentication_info = get_server_details_from_env()\n",
+    "geti_server_configuration = get_server_details_from_env()\n",
     "\n",
-    "geti = Geti(host=hostname, **authentication_info)"
+    "geti = Geti(server_config=geti_server_configuration)"
    ]
   },
   {

--- a/notebooks/008_deploy_project.ipynb
+++ b/notebooks/008_deploy_project.ipynb
@@ -17,14 +17,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# As usual, we will connect to the platform first, using the server details from the .env file\n",
+    "# As usual we will connect to the platform first, using the server details from the .env file\n",
     "\n",
     "from geti_sdk import Geti\n",
     "from geti_sdk.utils import get_server_details_from_env\n",
     "\n",
-    "hostname, authentication_info = get_server_details_from_env()\n",
+    "geti_server_configuration = get_server_details_from_env()\n",
     "\n",
-    "geti = Geti(host=hostname, **authentication_info)"
+    "geti = Geti(server_config=geti_server_configuration)"
    ]
   },
   {

--- a/notebooks/009_download_and_upload_project.ipynb
+++ b/notebooks/009_download_and_upload_project.ipynb
@@ -18,15 +18,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# As usual, we will connect to the platform first, using the server details from the .env file. We will also create a ProjectClient for the server\n",
+    "# As usual we will connect to the platform first, using the server details from the .env file. We will also create a ProjectClient for the server\n",
     "\n",
     "from geti_sdk import Geti\n",
     "from geti_sdk.rest_clients import ProjectClient\n",
     "from geti_sdk.utils import get_server_details_from_env\n",
     "\n",
-    "hostname, authentication_info = get_server_details_from_env()\n",
+    "geti_server_configuration = get_server_details_from_env()\n",
     "\n",
-    "geti = Geti(host=hostname, **authentication_info)\n",
+    "geti = Geti(server_config=geti_server_configuration)\n",
     "\n",
     "project_client = ProjectClient(session=geti.session, workspace_id=geti.workspace_id)"
    ]

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -55,6 +55,19 @@ is installed, you can follow the steps below to set up the notebooks.
 >
 > In case both a TOKEN and USERNAME/PASSWORD variables are provided, the SDK
 > will default to using the TOKEN since this method is considered more secure.
+>
+> ### SSL Certificate verification
+> By default, the SDK verifies the SSL certificate of your server before establishing
+> a connection over HTTPS. If the certificate can't be validated, this will results in
+> an error and the SDK will not be able to connect to the server.
+>
+> However, this may not be appropriate or desirable in all cases, for instance if your
+> Geti server does not have a certificate because you are running it in a private
+> network environment. In that case, certificate validation can be disabled by adding
+> the following variable to the `.env` file:
+> ```shell
+> VERIFY_CERT=0
+> ```
 
 # Available notebooks
 The following notebooks are currently provided:

--- a/notebooks/use_cases/101_simulate_low_light_product_inspection.ipynb
+++ b/notebooks/use_cases/101_simulate_low_light_product_inspection.ipynb
@@ -47,9 +47,9 @@
     "from geti_sdk import Geti\n",
     "from geti_sdk.utils import get_server_details_from_env\n",
     "\n",
-    "hostname, authentication_info = get_server_details_from_env(env_file_path=\"../.env\")\n",
+    "geti_server_configuration = get_server_details_from_env()\n",
     "\n",
-    "geti = Geti(host=hostname, **authentication_info)"
+    "geti = Geti(server_config=geti_server_configuration)"
    ]
   },
   {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,7 +181,9 @@ def pytest_sessionstart(session: Session) -> None:
         else:
             proxies = None
         # Remove existing test projects
-        remove_all_test_projects(Geti(host=HOST, **auth_params, proxies=proxies))
+        remove_all_test_projects(
+            Geti(host=HOST, **auth_params, proxies=proxies, verify_certificate=False)
+        )
     if TEST_MODE == SdkTestMode.RECORD:
         record_cassette_path = tempfile.mkdtemp()
         logging.info(f"Cassettes will be recorded to `{record_cassette_path}`.")

--- a/tests/fixtures/geti.py
+++ b/tests/fixtures/geti.py
@@ -84,5 +84,8 @@ def fxt_geti_no_vcr(
     else:
         auth_params = {"token": fxt_server_config.token}
     yield Geti(
-        host=fxt_server_config.host, proxies=fxt_server_config.proxies, **auth_params
+        host=fxt_server_config.host,
+        proxies=fxt_server_config.proxies,
+        **auth_params,
+        verify_certificate=fxt_server_config.has_valid_certificate,
     )

--- a/tests/integration/utils/test_utils.py
+++ b/tests/integration/utils/test_utils.py
@@ -93,11 +93,12 @@ class TestUtils:
         This also tests that getting the server details from the global environment
         works as expected.
         """
-        host, authentication_info = get_server_details_from_env(fxt_env_filepath)
+        server_config = get_server_details_from_env(fxt_env_filepath)
 
-        assert host == DUMMY_HOST
-        assert authentication_info["token"] == "this_is_a_fake_token"
-        assert len(authentication_info) == 1
+        assert server_config.host == f"https://{DUMMY_HOST}"
+        assert server_config.token == "this_is_a_fake_token"
+        assert not hasattr(server_config, "username")
+        assert not hasattr(server_config, "password")
 
         environ_keys = ["GETI_HOST", "GETI_USERNAME", "GETI_PASSWORD"]
         expected_results = {}
@@ -115,9 +116,8 @@ class TestUtils:
                 os.environ.update(variable_dictionary)
                 expected_results.update(variable_dictionary)
 
-        host, authentication_info = get_server_details_from_env(
-            use_global_variables=True
-        )
-        assert host == expected_results["GETI_HOST"]
-        assert authentication_info["username"] == expected_results["GETI_USERNAME"]
-        assert authentication_info["password"] == expected_results["GETI_PASSWORD"]
+        server_config = get_server_details_from_env(use_global_variables=True)
+        assert server_config.host == expected_results["GETI_HOST"]
+        assert server_config.username == expected_results["GETI_USERNAME"]
+        assert server_config.password == expected_results["GETI_PASSWORD"]
+        assert not hasattr(server_config, "token")

--- a/tests/integration/utils/test_utils.py
+++ b/tests/integration/utils/test_utils.py
@@ -117,7 +117,9 @@ class TestUtils:
                 expected_results.update(variable_dictionary)
 
         server_config = get_server_details_from_env(use_global_variables=True)
-        assert server_config.host == expected_results["GETI_HOST"]
+        assert server_config.host.replace("https://", "") == expected_results[
+            "GETI_HOST"
+        ].replace("https://", "")
         assert server_config.username == expected_results["GETI_USERNAME"]
         assert server_config.password == expected_results["GETI_PASSWORD"]
         assert not hasattr(server_config, "token")


### PR DESCRIPTION
This PR enables SSL certificate validation in the `Geti` class by default. It can still be disabled by passing `verify_certificate=False` to the Geti constructor.