### PR TITLE
Remove disallowed fields from project before POSTing

### DIFF
--- a/geti_sdk/data_models/label.py
+++ b/geti_sdk/data_models/label.py
@@ -55,6 +55,7 @@ class Label:
     """
 
     _identifier_fields: ClassVar[List[str]] = ["id", "hotkey"]
+    _GET_only_fields: ClassVar[List[str]] = ["is_empty", "is_anomalous"]
 
     name: str
     color: str
@@ -79,6 +80,16 @@ class Label:
             is_empty=self.is_empty,
             color=Color.from_hex_str(self.color),
         )
+
+    def prepare_for_post(self) -> None:
+        """
+        Set all fields to None that are not valid for making a POST request to the
+        /projects endpoint.
+
+        :return:
+        """
+        for field_name in self._GET_only_fields:
+            setattr(self, field_name, None)
 
 
 @attr.define

--- a/geti_sdk/data_models/project.py
+++ b/geti_sdk/data_models/project.py
@@ -140,6 +140,16 @@ class Pipeline:
         for task in self.tasks:
             task.deidentify()
 
+    def prepare_for_post(self) -> None:
+        """
+        Set all fields to None that are not valid for making a POST request to the
+        /projects endpoint.
+
+        :return:
+        """
+        for task in self.tasks:
+            task.prepare_for_post()
+
 
 @attr.define
 class Dataset:
@@ -151,6 +161,7 @@ class Dataset:
     """
 
     _identifier_fields: ClassVar[str] = ["id", "creation_time"]
+    _GET_only_fields: ClassVar[List[str]] = ["use_for_training", "creation_time"]
 
     name: str
     id: Optional[str] = None
@@ -162,6 +173,16 @@ class Dataset:
         Remove unique database ID from the Dataset.
         """
         deidentify(self)
+
+    def prepare_for_post(self) -> None:
+        """
+        Set all fields to None that are not valid for making a POST request to the
+        /projects endpoint.
+
+        :return:
+        """
+        for field_name in self._GET_only_fields:
+            setattr(self, field_name, None)
 
 
 @attr.define
@@ -184,6 +205,7 @@ class Project:
         "creation_time",
         "creator_id",
     ]
+    _GET_only_fields: ClassVar[List[str]] = ["thumbnail", "score", "performance"]
 
     name: str
     pipeline: Pipeline
@@ -234,6 +256,19 @@ class Project:
         self.pipeline.deidentify()
         for dataset in self.datasets:
             dataset.deidentify()
+
+    def prepare_for_post(self) -> None:
+        """
+        Set all fields to None that are not valid for making a POST request to the
+        /projects endpoint.
+
+        :return:
+        """
+        for field_name in self._GET_only_fields:
+            setattr(self, field_name, None)
+        self.pipeline.prepare_for_post()
+        for dataset in self.datasets:
+            dataset.prepare_for_post()
 
     def to_dict(self) -> Dict[str, Any]:
         """

--- a/geti_sdk/data_models/task.py
+++ b/geti_sdk/data_models/task.py
@@ -159,3 +159,21 @@ class Task:
                 f"Parent: {label.parent_id}\n"
             )
         return summary_str
+
+    def prepare_for_post(self) -> None:
+        """
+        Set all fields to None that are not valid for making a POST request to the
+        /projects endpoint.
+
+        :return:
+        """
+        if self.labels is not None:
+            labels_indices_to_pop: List[int] = []
+            for ii, label in enumerate(self.labels):
+                if label.is_empty:
+                    labels_indices_to_pop.append(ii)
+                label.prepare_for_post()
+            for index in labels_indices_to_pop:
+                # Empty labels are not allowed to be specified explicitly in a POST
+                # request
+                self.labels.pop(index)

--- a/geti_sdk/rest_clients/project_client/project_client.py
+++ b/geti_sdk/rest_clients/project_client/project_client.py
@@ -291,6 +291,7 @@ class ProjectClient:
             f"Creating project '{project.name}' from parameters in "
             f"configuration file at {path_to_project}."
         )
+        project.prepare_for_post()
         return self.get_or_create_project(**project.get_parameters())
 
     @staticmethod


### PR DESCRIPTION
Recently, the POST endpoint for project creation has added stricter validation of input data. Several fields that are returned by the GET /projects endpoint are no longer allowed in the POST. 

This PR removes those fields before POSTing to the /projects endpoint, when creating a project from a previously downloaded project (because in that case the disallowed fields will be present otherwise).