### PR TITLE
Use OTE SDK visualizer, add plot helper unit tests

### DIFF
--- a/geti_sdk/data_models/annotation_scene.py
+++ b/geti_sdk/data_models/annotation_scene.py
@@ -19,7 +19,7 @@ from typing import Any, ClassVar, Dict, List, Optional, Sequence, Tuple, Union
 import attr
 import cv2
 import numpy as np
-from ote_sdk.entities.annotation import AnnotationSceneEntity
+from ote_sdk.entities.annotation import AnnotationSceneEntity, AnnotationSceneKind
 
 from geti_sdk.data_models.annotations import Annotation
 from geti_sdk.data_models.enums import AnnotationKind
@@ -350,6 +350,24 @@ class AnnotationScene:
         return cls(
             annotations=annotations,
             id=ote_annotation_scene.id,
+        )
+
+    def to_ote(self, image_width: int, image_height: int) -> AnnotationSceneEntity:
+        """
+        Create an AnnotationSceneEntity object from OTE SDK from the Geti SDK
+        AnnotationScene instance
+
+        :param image_width: Width of the image to which the annotation scene applies
+        :param image_height: Height of the image to which the annotation scene applies
+        :return: OTE SDK AnnotationSceneEntity instance, corresponding to the current
+            AnnotationScene
+        """
+        annotations = [
+            annotation.to_ote(image_width=image_width, image_height=image_height)
+            for annotation in self.annotations
+        ]
+        return AnnotationSceneEntity(
+            annotations=annotations, kind=AnnotationSceneKind[self.kind.name]
         )
 
     def map_labels(

--- a/geti_sdk/data_models/annotations.py
+++ b/geti_sdk/data_models/annotations.py
@@ -119,6 +119,18 @@ class Annotation:
         ]
         return Annotation(shape=shape, labels=labels, id=ote_annotation.id)
 
+    def to_ote(self, image_width: int, image_height: int) -> OteAnnotation:
+        """
+        Create an OTE SDK Annotation object corresponding to this
+        :py:class:`~geti_sdk.data_models.annotations.Annotation` instance
+
+        :param image_width: Width of the image to which the annotation applies
+        :param image_height: Height of the image to which the annotation applies
+        """
+        shape = self.shape.to_ote(image_width=image_width, image_height=image_height)
+        labels = [label.to_ote() for label in self.labels]
+        return OteAnnotation(shape=shape, labels=labels)
+
     def map_labels(self, labels: Sequence[Union[ScoredLabel, Label]]) -> "Annotation":
         """
         Attempt to map the labels found in `labels` to those in the Annotation

--- a/geti_sdk/data_models/label.py
+++ b/geti_sdk/data_models/label.py
@@ -17,6 +17,8 @@ from typing import ClassVar, List, Optional, Tuple
 
 import attr
 from ote_sdk.entities.color import Color
+from ote_sdk.entities.color import Color as OteColor
+from ote_sdk.entities.label import Domain as OteLabelDomain
 from ote_sdk.entities.label import LabelEntity
 from ote_sdk.entities.scored_label import ScoredLabel as OteScoredLabel
 
@@ -159,4 +161,19 @@ class ScoredLabel:
             id=ote_label.id,
             probability=ote_label.probability,
             color=ote_label.color.hex_str,
+        )
+
+    def to_ote(self) -> OteScoredLabel:
+        """
+        Create a ScoredLabel object from OTE SDK corresponding to this
+        :py:class`~geti_sdk.data_models.label.ScoredLabel` instance.
+        """
+        return OteScoredLabel(
+            label=LabelEntity(
+                name=self.name,
+                color=OteColor(*self.color_tuple),
+                id=self.id,
+                domain=OteLabelDomain.NULL,
+            ),
+            probability=self.probability,
         )

--- a/geti_sdk/utils/plot_helpers.py
+++ b/geti_sdk/utils/plot_helpers.py
@@ -17,6 +17,7 @@ from typing import List, Optional, Union
 import cv2
 import numpy as np
 from IPython.display import display
+from ote_sdk.usecases.exportable_code.visualizers import Visualizer
 from PIL import Image as PILImage
 
 from geti_sdk.data_models.annotation_scene import AnnotationScene
@@ -30,17 +31,23 @@ def show_image_with_annotation_scene(
     annotation_scene: Union[AnnotationScene, Prediction],
     filepath: Optional[str] = None,
     show_in_notebook: bool = False,
-):
+    show_results: bool = True,
+) -> np.ndarray:
     """
     Display an image with an annotation_scene overlayed on top of it.
 
     :param image: Image to show prediction for
     :param annotation_scene: Annotations or Predictions to overlay on the image
     :param filepath: Optional filepath to save the image with annotation overlay to.
-        If left as None, the image will be shown in a new opencv window
+        If left as None, the result will not be saved to file
     :param show_in_notebook: True if the image needs to be shown in a notebook context.
         Setting this to True will display the image inline in the notebook. Setting it
         to False will open a pop up to show the image.
+    :param show_results: True to show the results. If `show_in_notebook` is True, this
+        will display the image with the annotations inside the notebook. If
+        `show_in_notebook` is False, a new opencv window will pop up. If
+        `show_results` is set to False, the results will not be shown but will only
+        be returned instead
     """
     if type(annotation_scene) == AnnotationScene:
         plot_type = "Annotation"
@@ -58,26 +65,33 @@ def show_image_with_annotation_scene(
     else:
         media_information = image.media_information
         name = image.name
-    mask = annotation_scene.as_mask(media_information)
+
+    window_name = f"{plot_type} for {name}"
+    visualizer = Visualizer(window_name=window_name)
+    ote_annotation_scene = annotation_scene.to_ote(
+        image_width=media_information.width, image_height=media_information.height
+    )
 
     if isinstance(image, np.ndarray):
-        result = image.copy()
+        numpy_image = image.copy()
     else:
-        result = image.numpy.copy()
-    result[np.sum(mask, axis=-1) > 0] = 0
-    result += mask[..., ::-1]
+        numpy_image = image.numpy.copy()
+
+    result = visualizer.draw(image=numpy_image, annotation=ote_annotation_scene)
 
     if filepath is None:
-        if not show_in_notebook:
-            cv2.imshow(f"{plot_type} for {name}", result)
-            cv2.waitKey(0)
-            cv2.destroyAllWindows()
-        else:
-            result = cv2.cvtColor(result, cv2.COLOR_BGR2RGB)
-            image = PILImage.fromarray(result)
-            display(image)
+        if show_results:
+            if not show_in_notebook:
+                cv2.imshow(window_name, result)
+                cv2.waitKey(0)
+                cv2.destroyAllWindows()
+            else:
+                image = PILImage.fromarray(result)
+                display(image)
     else:
         cv2.imwrite(filepath, result)
+
+    return result
 
 
 def show_video_frames_with_annotation_scenes(
@@ -97,8 +111,6 @@ def show_video_frames_with_annotation_scenes(
     :param filepath: Optional filepath to save the video with annotation overlay to.
         If left as None, the video frames will be shown in a new opencv window
     """
-    image_name = video_frames[0].name.split("_frame_")[0]
-
     first_frame = video_frames[0]
 
     out_writer: Optional[cv2.VideoWriter] = None
@@ -123,14 +135,18 @@ def show_video_frames_with_annotation_scenes(
                 f"Invalid input: Unable to plot object of type "
                 f"{type(annotation_scene)}."
             )
-        mask = annotation_scene.as_mask(frame.media_information)
+        ote_annotation = annotation_scene.to_ote(
+            image_width=frame.media_information.width,
+            image_height=frame.media_information.height,
+        )
 
-        result = frame.numpy.copy()
-        result[np.sum(mask, axis=-1) > 0] = 0
-        result += mask[..., ::-1]
+        numpy_frame = frame.numpy.copy()
+        window_name = f"{name} for '{frame.video_name}'"
+        visualizer = Visualizer(window_name=window_name)
+        result = visualizer.draw(numpy_frame, annotation=ote_annotation)
 
         if out_writer is None:
-            cv2.imshow(f"{name} for {image_name}", result)
+            cv2.imshow(window_name, result)
             cv2.waitKey(int(wait_time * 1000))
         else:
             out_writer.write(result)

--- a/tests/fixtures/unit_tests/annotation.py
+++ b/tests/fixtures/unit_tests/annotation.py
@@ -11,11 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions
 # and limitations under the License.
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, List
 
 import pytest
 
-from geti_sdk.data_models import Annotation, AnnotationScene, ScoredLabel
+from geti_sdk.data_models import (
+    Annotation,
+    AnnotationScene,
+    Image,
+    ScoredLabel,
+    Video,
+    VideoFrame,
+)
+from geti_sdk.data_models.containers import MediaList
+from geti_sdk.data_models.media_identifiers import ImageIdentifier
 from geti_sdk.data_models.shapes import Point, Polygon, Rectangle
 
 
@@ -95,9 +104,47 @@ def fxt_polygon_annotation_factory(
 
 @pytest.fixture()
 def fxt_annotation_scene(
+    fxt_geti_image: Image,
     fxt_rectangle_annotation_factory,
     fxt_polygon_annotation_factory,
-    fxt_image_identifier,
+) -> AnnotationScene:
+    width = fxt_geti_image.media_information.width
+    height = fxt_geti_image.media_information.height
+    yield AnnotationScene(
+        annotations=[
+            fxt_rectangle_annotation_factory(width, height),
+            fxt_polygon_annotation_factory(width, height),
+        ],
+        media_identifier=fxt_geti_image.identifier,
+    )
+
+
+@pytest.fixture()
+def fxt_video_annotation_scenes(
+    fxt_geti_video: Video,
+    fxt_rectangle_annotation_factory,
+    fxt_polygon_annotation_factory,
+    fxt_video_frames: MediaList[VideoFrame],
+) -> List[AnnotationScene]:
+    width = fxt_geti_video.media_information.width
+    height = fxt_geti_video.media_information.height
+    yield [
+        AnnotationScene(
+            annotations=[
+                fxt_rectangle_annotation_factory(width, height),
+                fxt_polygon_annotation_factory(width, height),
+            ],
+            media_identifier=video_frame.identifier,
+        )
+        for video_frame in fxt_video_frames
+    ]
+
+
+@pytest.fixture()
+def fxt_annotation_scene_from_normalized(
+    fxt_rectangle_annotation_factory,
+    fxt_polygon_annotation_factory,
+    fxt_image_identifier: ImageIdentifier,
 ) -> AnnotationScene:
     img_width = 1000
     img_height = 2000

--- a/tests/fixtures/unit_tests/dates.py
+++ b/tests/fixtures/unit_tests/dates.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+import datetime
+
+import pytest
+
+
+@pytest.fixture(scope="class")
+def fxt_datetime_string() -> str:
+    yield "2022-11-16T16:02:26.418801"
+
+
+@pytest.fixture(scope="class")
+def fxt_datetime(fxt_datetime_string: str) -> datetime.datetime:
+    yield datetime.datetime.fromisoformat(date_string=fxt_datetime_string)

--- a/tests/fixtures/unit_tests/media.py
+++ b/tests/fixtures/unit_tests/media.py
@@ -13,10 +13,25 @@
 # and limitations under the License.
 from typing import Dict
 
+import cv2
+import numpy as np
 import pytest
 
-from geti_sdk.data_models import MediaType
-from geti_sdk.data_models.media_identifiers import ImageIdentifier
+from geti_sdk.data_models import Image, MediaType
+from geti_sdk.data_models.containers import MediaList
+from geti_sdk.data_models.media import (
+    ImageInformation,
+    Video,
+    VideoFrame,
+    VideoInformation,
+)
+from geti_sdk.data_models.media_identifiers import ImageIdentifier, VideoIdentifier
+from geti_sdk.demos import EXAMPLE_IMAGE_PATH
+
+
+@pytest.fixture(scope="session")
+def fxt_numpy_image() -> np.ndarray:
+    yield cv2.imread(EXAMPLE_IMAGE_PATH)
 
 
 @pytest.fixture()
@@ -25,5 +40,80 @@ def fxt_image_identifier() -> ImageIdentifier:
 
 
 @pytest.fixture()
+def fxt_video_identifier() -> VideoIdentifier:
+    yield VideoIdentifier(video_id="video_0", type=MediaType.VIDEO)
+
+
+@pytest.fixture()
 def fxt_image_identifier_rest() -> Dict[str, str]:
     yield {"image_id": "image_0", "type": "image"}
+
+
+@pytest.fixture()
+def fxt_image_information(fxt_numpy_image: np.ndarray) -> ImageInformation:
+    yield ImageInformation(
+        display_url="dummy_url",
+        height=fxt_numpy_image.shape[0],
+        width=fxt_numpy_image.shape[1],
+    )
+
+
+@pytest.fixture(scope="session")
+def fxt_video_information(fxt_video_path_1_light_bulbs: str) -> VideoInformation:
+    cap = cv2.VideoCapture(fxt_video_path_1_light_bulbs)
+    if cap.isOpened():
+        width = cap.get(cv2.CAP_PROP_FRAME_WIDTH)
+        height = cap.get(cv2.CAP_PROP_FRAME_HEIGHT)
+        fps = cap.get(cv2.CAP_PROP_FPS)
+        count = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+        duration = count / fps
+
+    yield VideoInformation(
+        display_url="dummy_url/display/stream",
+        width=int(width),
+        height=int(height),
+        frame_count=int(count),
+        duration=duration,
+        frame_stride=50,
+    )
+
+
+@pytest.fixture()
+def fxt_geti_image(
+    fxt_numpy_image: np.ndarray,
+    fxt_image_information: ImageInformation,
+    fxt_image_identifier: ImageIdentifier,
+    fxt_datetime_string: str,
+) -> Image:
+    image = Image(
+        name="dummy_image",
+        id=fxt_image_identifier.image_id,
+        type=fxt_image_identifier.type,
+        media_information=fxt_image_information,
+        upload_time=fxt_datetime_string,
+    )
+    image._data = fxt_numpy_image
+    yield image
+
+
+@pytest.fixture()
+def fxt_geti_video(
+    fxt_video_path_1_light_bulbs: str,
+    fxt_video_identifier: VideoIdentifier,
+    fxt_video_information: VideoInformation,
+    fxt_datetime_string: str,
+) -> Video:
+    video = Video(
+        name="dummy_video",
+        id=fxt_video_identifier.video_id,
+        type=fxt_video_identifier.type,
+        upload_time=fxt_datetime_string,
+        media_information=fxt_video_information,
+    )
+    video._data = fxt_video_path_1_light_bulbs
+    yield video
+
+
+@pytest.fixture()
+def fxt_video_frames(fxt_geti_video: Video) -> MediaList[VideoFrame]:
+    yield fxt_geti_video.to_frames(include_data=True)

--- a/tests/pre-merge/unit/rest_converters/test_normalized_annotation_rest_converter_unit.py
+++ b/tests/pre-merge/unit/rest_converters/test_normalized_annotation_rest_converter_unit.py
@@ -68,10 +68,12 @@ class TestNormalizedAnnotationRESTConverter:
             * (int(img_heigth * y_max) - int(img_heigth * y_min))
         )
 
-    def test_to_normalized_dict(self, fxt_annotation_scene: AnnotationScene):
+    def test_to_normalized_dict(
+        self, fxt_annotation_scene_from_normalized: AnnotationScene
+    ):
         # Act
         annotation_rest = NormalizedAnnotationRESTConverter.to_normalized_dict(
-            fxt_annotation_scene, image_height=2000, image_width=1000
+            fxt_annotation_scene_from_normalized, image_height=2000, image_width=1000
         )
 
         # Assert

--- a/tests/pre-merge/unit/utils/test_plot_helpers_unit.py
+++ b/tests/pre-merge/unit/utils/test_plot_helpers_unit.py
@@ -1,0 +1,107 @@
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+import os
+from typing import List
+from unittest.mock import patch
+
+import numpy as np
+
+from geti_sdk.data_models import AnnotationScene, Image, VideoFrame
+from geti_sdk.data_models.containers import MediaList
+from geti_sdk.utils import (
+    show_image_with_annotation_scene,
+    show_video_frames_with_annotation_scenes,
+)
+
+
+class TestPlotHelpers:
+    def test_show_image_with_annotation_scene_cv2(
+        self,
+        fxt_annotation_scene: AnnotationScene,
+        fxt_numpy_image: np.ndarray,
+        fxt_geti_image: Image,
+        fxt_temp_directory: str,
+    ):
+        # Arrange
+        filepath = os.path.join(fxt_temp_directory, "dummy_results.jpg")
+
+        # Act
+        with patch("cv2.imshow") as mock_imshow, patch(
+            "cv2.waitKey"
+        ) as mock_waitkey, patch("cv2.destroyAllWindows") as mock_destroywindows, patch(
+            "cv2.imwrite"
+        ) as mock_imwrite:
+            result = show_image_with_annotation_scene(
+                image=fxt_numpy_image, annotation_scene=fxt_annotation_scene
+            )
+            result_geti = show_image_with_annotation_scene(
+                image=fxt_geti_image, annotation_scene=fxt_annotation_scene
+            )
+            results_no_show = show_image_with_annotation_scene(
+                image=fxt_geti_image,
+                annotation_scene=fxt_annotation_scene,
+                show_results=False,
+            )
+            results_filepath = show_image_with_annotation_scene(
+                image=fxt_geti_image,
+                annotation_scene=fxt_annotation_scene,
+                filepath=filepath,
+            )
+
+        # Assert
+        assert mock_imshow.call_count == 2
+        assert mock_waitkey.call_count == 2
+        assert mock_destroywindows.call_count == 2
+        mock_imwrite.assert_called_once()
+        assert result.shape == fxt_numpy_image.shape
+        assert result_geti.shape == fxt_numpy_image.shape
+        assert results_no_show.shape == fxt_numpy_image.shape
+        assert results_filepath.shape == fxt_numpy_image.shape
+
+    def test_show_image_with_annotation_scene_notebook(
+        self,
+        fxt_annotation_scene: AnnotationScene,
+        fxt_numpy_image: np.ndarray,
+    ):
+        # Act
+        with patch("geti_sdk.utils.plot_helpers.display") as mock_display:
+            result = show_image_with_annotation_scene(
+                image=fxt_numpy_image,
+                annotation_scene=fxt_annotation_scene,
+                show_in_notebook=True,
+            )
+
+        # Assert
+        mock_display.assert_called_once()
+        assert result.shape == fxt_numpy_image.shape
+
+    def test_show_video_frames_with_annotation_scenes(
+        self,
+        fxt_video_annotation_scenes: List[AnnotationScene],
+        fxt_video_frames: MediaList[VideoFrame],
+    ):
+        # Act
+        with patch("cv2.imshow") as mock_imshow, patch(
+            "cv2.waitKey"
+        ) as mock_waitkey, patch("cv2.destroyAllWindows") as mock_destroywindows:
+            show_video_frames_with_annotation_scenes(
+                video_frames=fxt_video_frames,
+                annotation_scenes=fxt_video_annotation_scenes,
+            )
+
+        # Assert
+        assert mock_imshow.call_count == len(fxt_video_frames)
+        assert mock_waitkey.call_count == len(fxt_video_frames)
+        mock_destroywindows.assert_called_once()


### PR DESCRIPTION
1. Enable the use of the OTE SDK `Visualizer` class to show annotations and predictions in images/videos, following the style of the Geti UI
2. Add unit tests for the `plot_helpers` module