### PR TITLE
Fix opencv window closure bug

### DIFF
--- a/geti_sdk/utils/plot_helpers.py
+++ b/geti_sdk/utils/plot_helpers.py
@@ -36,7 +36,8 @@ def show_image_with_annotation_scene(
     """
     Display an image with an annotation_scene overlayed on top of it.
 
-    :param image: Image to show prediction for
+    :param image: Image to show prediction for.
+        NOTE: `image` is expected to have R,G,B channel ordering
     :param annotation_scene: Annotations or Predictions to overlay on the image
     :param filepath: Optional filepath to save the image with annotation overlay to.
         If left as None, the result will not be saved to file
@@ -85,6 +86,7 @@ def show_image_with_annotation_scene(
                 cv2.imshow(window_name, result)
                 cv2.waitKey(0)
                 cv2.destroyAllWindows()
+                cv2.waitKey(1)
             else:
                 image = PILImage.fromarray(result)
                 display(image)

--- a/geti_sdk/utils/plot_helpers.py
+++ b/geti_sdk/utils/plot_helpers.py
@@ -155,5 +155,6 @@ def show_video_frames_with_annotation_scenes(
 
     if out_writer is None:
         cv2.destroyAllWindows()
+        cv2.waitKey(1)
     else:
         out_writer.release()

--- a/tests/pre-merge/unit/utils/test_plot_helpers_unit.py
+++ b/tests/pre-merge/unit/utils/test_plot_helpers_unit.py
@@ -62,7 +62,7 @@ class TestPlotHelpers:
 
         # Assert
         assert mock_imshow.call_count == 2
-        assert mock_waitkey.call_count == 2
+        assert mock_waitkey.call_count == 4
         assert mock_destroywindows.call_count == 2
         mock_imwrite.assert_called_once()
         assert result.shape == fxt_numpy_image.shape
@@ -103,5 +103,5 @@ class TestPlotHelpers:
 
         # Assert
         assert mock_imshow.call_count == len(fxt_video_frames)
-        assert mock_waitkey.call_count == len(fxt_video_frames)
+        assert mock_waitkey.call_count == len(fxt_video_frames) + 1
         mock_destroywindows.assert_called_once()


### PR DESCRIPTION
Add a `cv2.waitKey()` step after closing the window to prevent the process from stalling.