### PR TITLE
Update training client to handle new /train endpoint response

### DIFF
--- a/geti_sdk/platform_versions.py
+++ b/geti_sdk/platform_versions.py
@@ -70,6 +70,41 @@ class GetiVersion:
             else:
                 return self.time_tag > other.time_tag
 
+    def __lt__(self, other):
+        """
+        Return True if this GetiVersion instance is an earlier version than `other`
+
+        :param other: GetiVersion object to compare with
+        :raises: TypeError if `other` is not a GetiVersion instance
+        :return: True if this instance corresponds to an earlier version of the Intel
+            Geti platform than `other`
+        """
+        return not self > other
+
+    def __ge__(self, other):
+        """
+        Return True if this GetiVersion instance is a later or equivalent version than
+        `other`
+
+        :param other: GetiVersion object to compare with
+        :raises: TypeError if `other` is not a GetiVersion instance
+        :return: True if this instance corresponds to a later or equivalent version of
+            the Intel Geti platform than `other`
+        """
+        return (self > other) or (self == other)
+
+    def __le__(self, other):
+        """
+        Return True if this GetiVersion instance is an earlier or equivalent version
+        than `other`
+
+        :param other: GetiVersion object to compare with
+        :raises: TypeError if `other` is not a GetiVersion instance
+        :return: True if this instance corresponds to an earlier or equivalent version
+            of the Intel Geti platform than `other`
+        """
+        return (self < other) or (self == other)
+
     def __eq__(self, other):
         """
         Return True if this GetiVersion instance is equal to `other`
@@ -82,7 +117,7 @@ class GetiVersion:
             raise TypeError(
                 f"Unsupported comparison operation, {other} is not a GetiVersion."
             )
-        return self.time_tag == other.time_tag and self.version == other.version
+        return self.version == other.version
 
     @property
     def is_sc_mvp(self) -> bool:
@@ -133,3 +168,9 @@ class GetiVersion:
             and self.time_tag >= self._GETI10_TIMETAG
             and not (self.is_sc_1_1 or self.is_sc_mvp)
         )
+
+
+SC_MVP_VERSION = GetiVersion("1.0.0-release-20220129184214")
+SC_11_VERSION = GetiVersion("1.1.0-release-20220624125113")
+GETI_10_VERSION = GetiVersion("1.0.0-release-20221005164936")
+GETI_11_VERSION = GetiVersion("1.1.0-latest-20221125121144")

--- a/geti_sdk/platform_versions.py
+++ b/geti_sdk/platform_versions.py
@@ -79,7 +79,7 @@ class GetiVersion:
         :return: True if this instance corresponds to an earlier version of the Intel
             Geti platform than `other`
         """
-        return not self > other
+        return not self >= other
 
     def __ge__(self, other):
         """

--- a/geti_sdk/rest_clients/training_client.py
+++ b/geti_sdk/rest_clients/training_client.py
@@ -26,7 +26,8 @@ from geti_sdk.data_models import (
 from geti_sdk.data_models.containers import AlgorithmList
 from geti_sdk.data_models.enums import JobState
 from geti_sdk.data_models.project import Dataset
-from geti_sdk.http_session import GetiSession
+from geti_sdk.http_session import GetiRequestException, GetiSession
+from geti_sdk.platform_versions import GETI_11_VERSION
 from geti_sdk.rest_converters import (
     ConfigurationRESTConverter,
     JobRESTConverter,
@@ -94,6 +95,26 @@ class TrainingClient:
             ]
         else:
             return job_list
+
+    def get_job_by_id(self, job_id: str) -> Optional[Job]:
+        """
+        Return the details of a Job by its `job_id`.
+
+        :param job_id: ID of the job to retrieve
+        :return: Job instance containing detailed information and status of the job.
+            If no job by the specified ID is found on the Intel® Geti™ platform, this
+            method returns None
+        """
+        try:
+            response = self.session.get_rest_response(
+                url=f"workspaces/{self.workspace_id}/jobs/{job_id}", method="GET"
+            )
+        except GetiRequestException as error:
+            if error.status_code == 404:
+                return None
+            else:
+                raise error
+        return JobRESTConverter.from_dict(response)
 
     def get_algorithms_for_task(self, task: Union[Task, int]) -> AlgorithmList:
         """
@@ -178,7 +199,15 @@ class TrainingClient:
         response = self.session.get_rest_response(
             url=f"{self.base_url}/train", method="POST", data=data
         )
-        job = JobRESTConverter.from_dict(response)
+
+        if self.session.version < GETI_11_VERSION:
+            job = JobRESTConverter.from_dict(response)
+            job_id = job.id
+        else:
+            job_id = response["job_ids"][0]
+            job = self.get_job_by_id(job_id=job_id)
+
+        logging.info(f"Training job with ID {job_id} submitted successfully.")
         job.workspace_id = self.workspace_id
         return job
 

--- a/tests/pre-merge/unit/test_platform_version_unit.py
+++ b/tests/pre-merge/unit/test_platform_version_unit.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-from geti_sdk.platform_versions import GetiVersion
+from geti_sdk.platform_versions import (
+    GETI_10_VERSION,
+    GETI_11_VERSION,
+    SC_11_VERSION,
+    SC_MVP_VERSION,
+)
 
 
 class TestGetiVersion:
@@ -21,25 +26,17 @@ class TestGetiVersion:
         Test parsing the version from a version string, for different release versions
         of the Intel Geti platform. Also test comparisons between versions
         """
-        # Arrange
-        SC_MVP = "1.0.0-release-20220129184214"
-        SC_11 = "1.1.0-release-20220624125113"
-        GETI_10 = "1.0.0-release-20221005164936"
 
-        # Act
-        mvp_version = GetiVersion(SC_MVP)
-        sc11_version = GetiVersion(SC_11)
-        geti10_version = GetiVersion(GETI_10)
-
-        # Assert
-        assert mvp_version.is_sc_mvp and not mvp_version.is_geti
+        assert SC_MVP_VERSION.is_sc_mvp and not SC_MVP_VERSION.is_geti
         assert (
-            sc11_version.is_sc_1_1
-            and not sc11_version.is_geti
-            and not sc11_version.is_sc_mvp
+            SC_11_VERSION.is_sc_1_1
+            and not SC_11_VERSION.is_geti
+            and not SC_11_VERSION.is_sc_mvp
         )
-        assert geti10_version.is_geti and geti10_version.is_geti_1_0
+        assert GETI_10_VERSION.is_geti and GETI_10_VERSION.is_geti_1_0
 
-        assert geti10_version > sc11_version
-        assert sc11_version > mvp_version
-        assert not mvp_version > geti10_version
+        assert GETI_10_VERSION > SC_11_VERSION
+        assert SC_11_VERSION > SC_MVP_VERSION
+        assert not SC_MVP_VERSION > GETI_10_VERSION
+        assert GETI_10_VERSION < GETI_11_VERSION
+        assert GETI_11_VERSION >= GETI_10_VERSION


### PR DESCRIPTION
The response for the /train endpoint has changed in Geti v1.1. This PR updates the training client to handle the new response