### PR TITLE
Fix issue with temporary resource clean up for `Deployment`s

### DIFF
--- a/geti_sdk/deployment/deployed_model.py
+++ b/geti_sdk/deployment/deployed_model.py
@@ -306,16 +306,22 @@ class DeployedModel(OptimizedModel):
             )
         os.makedirs(path_to_folder, exist_ok=True, mode=0o770)
 
+        new_model_data_path = os.path.join(path_to_folder, MODEL_DIR_NAME)
+        new_model_python_path = os.path.join(path_to_folder, PYTHON_DIR_NAME)
+
         shutil.copytree(
             src=self._model_data_path,
-            dst=os.path.join(path_to_folder, MODEL_DIR_NAME),
+            dst=new_model_data_path,
             dirs_exist_ok=True,
         )
         shutil.copytree(
             src=self._model_python_path,
-            dst=os.path.join(path_to_folder, PYTHON_DIR_NAME),
+            dst=new_model_python_path,
             dirs_exist_ok=True,
         )
+
+        self._model_data_path = new_model_data_path
+        self._model_python_path = new_model_python_path
 
         config_dict = ConfigurationRESTConverter.configuration_to_minimal_dict(
             self.hyper_parameters

--- a/geti_sdk/rest_clients/deployment_client.py
+++ b/geti_sdk/rest_clients/deployment_client.py
@@ -381,11 +381,4 @@ class DeploymentClient:
         # Save the deployment, if needed
         if output_folder is not None:
             deployment.save(path_to_folder=output_folder)
-
-            # Reload the deployment, and remove any temporary files left behind
-            deployment_from_disk = Deployment.from_folder(
-                path_to_folder=os.path.join(output_folder, "deployment")
-            )
-            self._clean_up_temporary_resources(deployment_id=code_deployment.id)
-            return deployment_from_disk
         return deployment


### PR DESCRIPTION
This PR moves the responsibility for cleaning up temporary resource from the `DeploymentClient` to the `Deployment` itself. This fixes an issue that could cause the resources to be removed prematurely.