### PR TITLE
Cvs-96625 Update image display method in `show_image_with_annotation_scene`

### DIFF
--- a/examples/upload_and_predict_from_numpy.py
+++ b/examples/upload_and_predict_from_numpy.py
@@ -55,7 +55,8 @@ if __name__ == "__main__":
     # --------------------------------------------------
 
     # First, we load the image as a numpy array using opencv
-    numpy_image = cv2.imread(PATH_TO_IMAGE)
+    bgr_image = cv2.imread(PATH_TO_IMAGE)
+    numpy_image = cv2.cvtColor(bgr_image, cv2.COLOR_BGR2RGB)
 
     # Rotate the image by 20 degrees
     rotated_image = rotate_image(image=numpy_image, angle=20)
@@ -77,9 +78,7 @@ if __name__ == "__main__":
     )
     filepath = "example_prediction.jpg"
     # Save the result to a file
-    show_image_with_annotation_scene(
-        image=sc_image, annotation_scene=image_prediction, filepath=filepath
-    )
+    show_image_with_annotation_scene(image=sc_image, annotation_scene=image_prediction)
     print(f"Prediction for the example image was saved to file: '{filepath}'")
 
     # We can do the same with videos. For example, to investigate the effect image

--- a/geti_sdk/data_models/media.py
+++ b/geti_sdk/data_models/media.py
@@ -232,6 +232,8 @@ class Image(MediaItem):
         empty, it will download the data using the provided session. Otherwise it
         will return the cached data directly
 
+        NOTE: The pixel data will be returned in BGR channel order
+
         :param session: REST session to the Intel® Geti™ server on which the Image lives
         :raises ValueError: If the cache is empty and no data can be downloaded
             from the cluster

--- a/geti_sdk/utils/plot_helpers.py
+++ b/geti_sdk/utils/plot_helpers.py
@@ -82,14 +82,11 @@ def show_image_with_annotation_scene(
 
     if filepath is None:
         if show_results:
+            pil_image = PILImage.fromarray(result)
             if not show_in_notebook:
-                cv2.imshow(window_name, result)
-                cv2.waitKey(0)
-                cv2.destroyAllWindows()
-                cv2.waitKey(1)
+                pil_image.show(title=window_name)
             else:
-                image = PILImage.fromarray(result)
-                display(image)
+                display(pil_image)
     else:
         success, buffer = cv2.imencode(".jpg", result)
         if success:

--- a/geti_sdk/utils/plot_helpers.py
+++ b/geti_sdk/utils/plot_helpers.py
@@ -32,12 +32,12 @@ def show_image_with_annotation_scene(
     filepath: Optional[str] = None,
     show_in_notebook: bool = False,
     show_results: bool = True,
+    channel_order: str = "rgb",
 ) -> np.ndarray:
     """
     Display an image with an annotation_scene overlayed on top of it.
 
     :param image: Image to show prediction for.
-        NOTE: `image` is expected to have R,G,B channel ordering
     :param annotation_scene: Annotations or Predictions to overlay on the image
     :param filepath: Optional filepath to save the image with annotation overlay to.
         If left as None, the result will not be saved to file
@@ -49,6 +49,9 @@ def show_image_with_annotation_scene(
         `show_in_notebook` is False, a new opencv window will pop up. If
         `show_results` is set to False, the results will not be shown but will only
         be returned instead
+    :param channel_order: The channel order (R,G,B or B,G,R) used for the input image.
+        This parameter accepts either `rgb` or `bgr` as input values, and defaults to
+        `rgb`.
     """
     if type(annotation_scene) == AnnotationScene:
         plot_type = "Annotation"
@@ -78,15 +81,26 @@ def show_image_with_annotation_scene(
     else:
         numpy_image = image.numpy.copy()
 
-    result = visualizer.draw(image=numpy_image, annotation=ote_annotation_scene)
+    if channel_order == "bgr":
+        rgb_image = cv2.cvtColor(numpy_image, cv2.COLOR_BGR2RGB)
+    elif channel_order == "rgb":
+        rgb_image = numpy_image
+    else:
+        raise ValueError(
+            f"Invalid channel order '{channel_order}'. Please use either `rgb` or "
+            f"`bgr`."
+        )
+
+    result = visualizer.draw(image=rgb_image, annotation=ote_annotation_scene)
 
     if filepath is None:
         if show_results:
-            pil_image = PILImage.fromarray(result)
+            rgb_result = cv2.cvtColor(result, cv2.COLOR_BGR2RGB)
+            image = PILImage.fromarray(rgb_result)
             if not show_in_notebook:
-                pil_image.show(title=window_name)
+                image.show(title=window_name)
             else:
-                display(pil_image)
+                display(image)
     else:
         success, buffer = cv2.imencode(".jpg", result)
         if success:

--- a/notebooks/001_create_project.ipynb
+++ b/notebooks/001_create_project.ipynb
@@ -395,7 +395,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/notebooks/002_create_project_from_dataset.ipynb
+++ b/notebooks/002_create_project_from_dataset.ipynb
@@ -33,18 +33,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "14ec7858",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from geti_sdk import Geti\n",
     "\n",
     "geti = Geti(server_config=geti_server_configuration)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -202,7 +206,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/notebooks/003_upload_and_predict_image.ipynb
+++ b/notebooks/003_upload_and_predict_image.ipynb
@@ -213,7 +213,9 @@
     "# downloaded and cached only on the first call to this method\n",
     "image.get_data(geti.session)\n",
     "\n",
-    "show_image_with_annotation_scene(image, prediction, show_in_notebook=True)"
+    "show_image_with_annotation_scene(\n",
+    "    image, prediction, show_in_notebook=True, channel_order=\"bgr\"\n",
+    ");"
    ]
   },
   {
@@ -238,7 +240,9 @@
     "    visualise_output=False,\n",
     "    delete_after_prediction=False,\n",
     ")\n",
-    "show_image_with_annotation_scene(quick_image, quick_prediction, show_in_notebook=True)"
+    "show_image_with_annotation_scene(\n",
+    "    quick_image, quick_prediction, show_in_notebook=True, channel_order=\"bgr\"\n",
+    ");"
    ]
   },
   {
@@ -266,7 +270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/notebooks/005_modify_image.ipynb
+++ b/notebooks/005_modify_image.ipynb
@@ -231,7 +231,9 @@
     "\n",
     "# Inspect the annotation\n",
     "print(annotation.overview)\n",
-    "show_image_with_annotation_scene(image, annotation, show_in_notebook=True);"
+    "show_image_with_annotation_scene(\n",
+    "    image, annotation, show_in_notebook=True, channel_order=\"bgr\"\n",
+    ");"
    ]
   },
   {

--- a/notebooks/005_modify_image.ipynb
+++ b/notebooks/005_modify_image.ipynb
@@ -231,7 +231,7 @@
     "\n",
     "# Inspect the annotation\n",
     "print(annotation.overview)\n",
-    "show_image_with_annotation_scene(image, annotation, show_in_notebook=True)"
+    "show_image_with_annotation_scene(image, annotation, show_in_notebook=True);"
    ]
   },
   {
@@ -278,7 +278,7 @@
     "    grayscale_image.get_data(geti.session),\n",
     "    grayscale_annotation,\n",
     "    show_in_notebook=True,\n",
-    ")"
+    ");"
    ]
   },
   {
@@ -340,7 +340,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/notebooks/008_deploy_project.ipynb
+++ b/notebooks/008_deploy_project.ipynb
@@ -414,7 +414,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/tests/pre-merge/unit/utils/test_plot_helpers_unit.py
+++ b/tests/pre-merge/unit/utils/test_plot_helpers_unit.py
@@ -38,9 +38,7 @@ class TestPlotHelpers:
         filepath = os.path.join(fxt_temp_directory, "dummy_results.jpg")
 
         # Act
-        with patch("cv2.imshow") as mock_imshow, patch(
-            "cv2.waitKey"
-        ) as mock_waitkey, patch("cv2.destroyAllWindows") as mock_destroywindows:
+        with patch("geti_sdk.utils.plot_helpers.PILImage.show") as mock_imshow:
             result = show_image_with_annotation_scene(
                 image=fxt_numpy_image, annotation_scene=fxt_annotation_scene
             )
@@ -60,8 +58,6 @@ class TestPlotHelpers:
 
         # Assert
         assert mock_imshow.call_count == 2
-        assert mock_waitkey.call_count == 4
-        assert mock_destroywindows.call_count == 2
         assert result.shape == fxt_numpy_image.shape
         assert result_geti.shape == fxt_numpy_image.shape
         assert results_no_show.shape == fxt_numpy_image.shape

--- a/tests/pre-merge/unit/utils/test_plot_helpers_unit.py
+++ b/tests/pre-merge/unit/utils/test_plot_helpers_unit.py
@@ -38,7 +38,7 @@ class TestPlotHelpers:
         filepath = os.path.join(fxt_temp_directory, "dummy_results.jpg")
 
         # Act
-        with patch("geti_sdk.utils.plot_helpers.PILImage.show") as mock_imshow:
+        with patch("geti_sdk.utils.plot_helpers.PILImage.Image.show") as mock_imshow:
             result = show_image_with_annotation_scene(
                 image=fxt_numpy_image, annotation_scene=fxt_annotation_scene
             )


### PR DESCRIPTION
`show_image_with_annotation_scene` now uses PIL to display images, instead of openCV.

This PR also adds a `channel_order` input parameter that accepts either `rgb` (default) or `bgr`. It should be set to reflect the channel order of the input image.