### PR TITLE
Fix deployment saving mechanism and handle errors

### DIFF
--- a/geti_sdk/deployment/deployed_model.py
+++ b/geti_sdk/deployment/deployed_model.py
@@ -15,6 +15,7 @@
 import datetime
 import importlib.util
 import json
+import logging
 import os
 import shutil
 import sys
@@ -329,11 +330,12 @@ class DeployedModel(OptimizedModel):
         deployed_model.get_data(source=path_to_folder)
         return deployed_model
 
-    def save(self, path_to_folder: Union[str, os.PathLike]):
+    def save(self, path_to_folder: Union[str, os.PathLike]) -> bool:
         """
         Save the DeployedModel instance to the designated folder.
 
         :param path_to_folder: Path to the folder to save the model to
+        :return: True if the model was saved successfully, False otherwise
         """
         if self._model_data_path is None:
             raise ValueError(
@@ -344,6 +346,16 @@ class DeployedModel(OptimizedModel):
 
         new_model_data_path = os.path.join(path_to_folder, MODEL_DIR_NAME)
         new_model_python_path = os.path.join(path_to_folder, PYTHON_DIR_NAME)
+
+        if (
+            new_model_python_path == self._model_python_path
+            or new_model_data_path == self._model_data_path
+        ):
+            logging.warning(
+                f"Model '{self.name}' already exist in target path {path_to_folder}, "
+                f"please save to a different location."
+            )
+            return False
 
         shutil.copytree(
             src=self._model_data_path,

--- a/notebooks/008_deploy_project.ipynb
+++ b/notebooks/008_deploy_project.ipynb
@@ -67,7 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "PROJECT_NAME = \"COCO multitask animal demo\""
+    "PROJECT_NAME = \"COCO dog detection\""
    ]
   },
   {
@@ -185,7 +185,7 @@
    "source": [
     "from geti_sdk.utils import show_image_with_annotation_scene\n",
     "\n",
-    "show_image_with_annotation_scene(numpy_image, prediction, show_in_notebook=True)"
+    "show_image_with_annotation_scene(numpy_rgb, prediction, show_in_notebook=True);"
    ]
   },
   {
@@ -366,8 +366,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_image_with_annotation_scene(sc_image, platform_prediction, show_in_notebook=True)\n",
-    "show_image_with_annotation_scene(numpy_image, local_prediction, show_in_notebook=True)"
+    "show_image_with_annotation_scene(\n",
+    "    sc_image, platform_prediction, show_in_notebook=True, channel_order=\"bgr\"\n",
+    ")\n",
+    "show_image_with_annotation_scene(numpy_rgb, local_prediction, show_in_notebook=True);"
    ]
   },
   {


### PR DESCRIPTION
Saving `deployments` works again, and it is no longer possible to save a deployment to the same target folder twice. Previously this would lead to data corruption, now this will result in a failed `deployment.save` operation while preserving the deployment in the target location.