### PR TITLE
Fix nightly tests for classification project

### DIFF
--- a/tests/helpers/project_helpers.py
+++ b/tests/helpers/project_helpers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 import logging
-from typing import List, Sequence
+from typing import List, Optional, Sequence
 
 from geti_sdk import Geti
 from geti_sdk.annotation_readers import AnnotationReader
@@ -30,6 +30,7 @@ def get_or_create_annotated_project_for_test_class(
     project_type: str = "detection",
     enable_auto_train: bool = False,
     learning_parameter_settings: str = "minimal",
+    annotation_requirements_first_training: Optional[int] = None,
 ):
     """
     This function returns an annotated project with `project_name` of type
@@ -66,6 +67,10 @@ def get_or_create_annotated_project_for_test_class(
             logging.info(
                 f"Invalid learning parameter settings '{learning_parameter_settings}' "
                 f"specified, continuing with default hyper parameters."
+            )
+        if annotation_requirements_first_training is not None:
+            project_service.set_auto_training_annotation_requirement(
+                required_images=annotation_requirements_first_training
             )
 
         project_service.add_annotated_media(

--- a/tests/helpers/project_service.py
+++ b/tests/helpers/project_service.py
@@ -460,7 +460,5 @@ class ProjectService:
             f"{self.project.name}_set_auto_training_annotation_requirement.{CASSETTE_EXTENSION}"
         ):
             self.configuration_client.set_project_parameter(
-                parameter_name="required_images_auto_training",
-                value=required_images,
-                parameter_group_name="Annotation requirements",
+                parameter_name="required_images_auto_training", value=required_images
             )

--- a/tests/helpers/project_service.py
+++ b/tests/helpers/project_service.py
@@ -445,3 +445,22 @@ class ProjectService:
                     )
                     task_hypers.batch_size.value = 1
                     self.configuration_client.set_configuration(task_hypers)
+
+    def set_auto_training_annotation_requirement(
+        self, required_images: int = 6
+    ) -> None:
+        """
+        Sets the 'Number of images required for auto-training' parameter for all
+        tasks in the project to `required_images`
+
+        :param required_images: Number of images required before starting a new round
+            of auto training for the task
+        """
+        with self.vcr_context(
+            f"{self.project.name}_set_auto_training_annotation_requirement.{CASSETTE_EXTENSION}"
+        ):
+            self.configuration_client.set_project_parameter(
+                parameter_name="required_images_auto_training",
+                value=required_images,
+                parameter_group_name="Annotation requirements",
+            )

--- a/tests/nightly/test_nightly_project.py
+++ b/tests/nightly/test_nightly_project.py
@@ -66,6 +66,7 @@ class TestNightlyProject:
             project_name=f"{PROJECT_PREFIX}_nightly_{self.PROJECT_TYPE}",
             enable_auto_train=True,
             learning_parameter_settings=fxt_learning_parameter_settings,
+            annotation_requirements_first_training=6,
         )
 
     def test_monitor_jobs(self, fxt_project_service_no_vcr: ProjectService):


### PR DESCRIPTION
To make sure auto-training is started after project creation and media upload, the annotation requirements are set to 6 instead of 12 for the nightly tests.