### PR TITLE
Add `explain` method for deployment

### DIFF
--- a/geti_sdk/data_models/predictions.py
+++ b/geti_sdk/data_models/predictions.py
@@ -113,6 +113,10 @@ class Prediction(AnnotationScene):
         applies
     :var modified: Date and time at which this Prediction was last modified
     :var maps: List of additional result media belonging to this prediction
+    :var feature_vector: Optional feature vector (produced by the model) for the image
+        to which the prediction relates
+    :var active_score: Optional active score (produced by the model) for the image
+        to which the prediction relates
     """
 
     kind: str = attr.field(
@@ -121,6 +125,8 @@ class Prediction(AnnotationScene):
         kw_only=True,
     )
     maps: List[ResultMedium] = attr.field(factory=list, kw_only=True)
+    feature_vector: Optional[np.ndarray] = attr.field(kw_only=True, default=None)
+    active_score: Optional[float] = attr.field(kw_only=True, default=None)
 
     def resolve_labels_for_result_media(self, labels: List[Label]) -> None:
         """

--- a/geti_sdk/data_models/predictions.py
+++ b/geti_sdk/data_models/predictions.py
@@ -125,8 +125,9 @@ class Prediction(AnnotationScene):
         kw_only=True,
     )
     maps: List[ResultMedium] = attr.field(factory=list, kw_only=True)
-    feature_vector: Optional[np.ndarray] = attr.field(kw_only=True, default=None)
-    active_score: Optional[float] = attr.field(kw_only=True, default=None)
+    feature_vector: Optional[np.ndarray] = attr.field(
+        kw_only=True, default=None, repr=False
+    )
 
     def resolve_labels_for_result_media(self, labels: List[Label]) -> None:
         """

--- a/geti_sdk/deployment/deployed_model.py
+++ b/geti_sdk/deployment/deployed_model.py
@@ -457,7 +457,7 @@ class DeployedModel(OptimizedModel):
         self,
         inference_results: Dict[str, np.ndarray],
         metadata: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[np.ndarray, np.ndarray, float]:
+    ) -> Tuple[np.ndarray, np.ndarray]:
         """
         Postprocess the model outputs to obtain saliency maps, feature vectors and
         active scores.
@@ -467,15 +467,32 @@ class DeployedModel(OptimizedModel):
         :return: Tuple containing postprocessed outputs, formatted as follows:
             - Numpy array containing the saliency map
             - Numpy array containing the feature vector
-            - floating point number representing the active score
         """
-        (
-            _,
-            saliency_map,
-            repr_vector,
-            act_score,
-        ) = self._inference_model.postprocess_aux_outputs(inference_results, metadata)
-        return saliency_map, repr_vector, act_score
+        saliency_key = "saliency_map"
+        fvector_key = "feature_vector"
+        if hasattr(self._inference_model, "postprocess_aux_outputs"):
+            (
+                _,
+                saliency_map,
+                repr_vector,
+                _,
+            ) = self._inference_model.postprocess_aux_outputs(
+                inference_results, metadata
+            )
+        elif (
+            saliency_key in inference_results.keys()
+            and fvector_key in inference_results.keys()
+        ):
+            saliency_map = inference_results[saliency_key]
+            repr_vector = inference_results[fvector_key]
+        elif saliency_key in metadata.keys() and fvector_key in metadata.keys():
+            saliency_map = metadata[saliency_key]
+            repr_vector = metadata[fvector_key]
+        else:
+            logging.warning("No saliency map or feature vector found in model output")
+            saliency_map = None
+            repr_vector = None
+        return saliency_map, repr_vector
 
     def infer(self, preprocessed_image: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
         """

--- a/geti_sdk/deployment/deployed_model.py
+++ b/geti_sdk/deployment/deployed_model.py
@@ -453,6 +453,30 @@ class DeployedModel(OptimizedModel):
         """
         return self._inference_model.postprocess(inference_results, metadata)
 
+    def postprocess_explain_outputs(
+        self,
+        inference_results: Dict[str, np.ndarray],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[np.ndarray, np.ndarray, float]:
+        """
+        Postprocess the model outputs to obtain saliency maps, feature vectors and
+        active scores.
+
+        :param inference_results: Dictionary holding the results of inference
+        :param metadata: Dictionary holding metadata
+        :return: Tuple containing postprocessed outputs, formatted as follows:
+            - Numpy array containing the saliency map
+            - Numpy array containing the feature vector
+            - floating point number representing the active score
+        """
+        (
+            _,
+            saliency_map,
+            repr_vector,
+            act_score,
+        ) = self._inference_model.postprocess_aux_outputs(inference_results, metadata)
+        return saliency_map, repr_vector, act_score
+
     def infer(self, preprocessed_image: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
         """
         Run inference on an already preprocessed image.

--- a/geti_sdk/deployment/deployment.py
+++ b/geti_sdk/deployment/deployment.py
@@ -34,6 +34,7 @@ from geti_sdk.data_models.shapes import Polygon, Rectangle, RotatedRectangle
 from geti_sdk.deployment.data_models import ROI, IntermediateInferenceResult
 from geti_sdk.rest_converters import ProjectRESTConverter
 
+from ..data_models.predictions import ResultMedium
 from .deployed_model import DeployedModel
 from .utils import OVMS_README_PATH, generate_ovms_model_name
 
@@ -209,16 +210,160 @@ class Deployment:
             with the channels in RGB order
         :return: inference results
         """
+        self._check_models_loaded()
+
+        # Single task inference
+        if self.is_single_task:
+            prediction = self._infer_task(
+                image, task=self.project.get_trainable_tasks()[0], explain=False
+            )
+        # Multi-task inference
+        else:
+            prediction = self._infer_pipeline(image=image, explain=False)
+        return prediction
+
+    def explain(self, image: np.ndarray) -> Prediction:
+        """
+        Run inference on an image for the full model chain in the deployment. The
+        resulting prediction will also contain a saliency map, feature vector and
+        active score for the input image.
+
+        :param image: Image to run inference on, as a numpy array containing the pixel
+            data. The image is expected to have dimensions [height x width x channels],
+            with the channels in RGB order
+        :return: inference results
+        """
+        self._check_models_loaded()
+
+        # Single task inference
+        if self.is_single_task:
+            prediction = self._infer_task(
+                image, task=self.project.get_trainable_tasks()[0], explain=True
+            )
+        # Multi-task inference
+        else:
+            prediction = self._infer_pipeline(image=image, explain=True)
+        return prediction
+
+    def _check_models_loaded(self) -> None:
+        """
+        Check if models are loaded and ready for inference.
+
+        :raises: ValueError in case models are not loaded
+        """
         if not self.are_models_loaded:
             raise ValueError(
                 f"Deployment '{self}' is not ready to infer, the inference models are "
                 f"not loaded. Please call 'load_inference_models' first."
             )
 
-        # Single task inference
-        if self.is_single_task:
-            return self._infer_task(image, task=self.project.get_trainable_tasks()[0])
+    def _infer_task(
+        self, image: np.ndarray, task: Task, explain: bool = False
+    ) -> Prediction:
+        """
+        Run pre-processing, inference, and post-processing on the input `image`, for
+        the model associated with the `task`.
 
+        :param image: Image to run inference on
+        :param task: Task to run inference for
+        :param explain: True to get additional outputs for model explainability,
+            including saliency maps, the feature vector and active score for the image
+        :return: Inference result
+        """
+        model = self._get_model_for_task(task)
+        preprocessed_image, metadata = model.preprocess(image)
+        inference_results = model.infer(preprocessed_image)
+        postprocessing_results = model.postprocess(inference_results, metadata=metadata)
+
+        # Optional output related to explainability
+        saliency_map: Optional[np.ndarray] = None
+        repr_vector: Optional[np.ndarray] = None
+        act_score: Optional[float] = None
+        if explain:
+            saliency_map, repr_vector, act_score = model.postprocess_explain_outputs(
+                inference_results=inference_results, metadata=metadata
+            )
+        converter = self._inference_converters[task.title]
+
+        width: int = image.shape[1]
+        height: int = image.shape[0]
+
+        try:
+            n_outputs = len(postprocessing_results)
+        except TypeError:
+            n_outputs = 1
+
+        if n_outputs != 0:
+            # The try/except is a workaround to handle different detection inference
+            # results by different ote sdk versions
+            try:
+                annotation_scene_entity = converter.convert_to_annotation(
+                    predictions=postprocessing_results, metadata=metadata
+                )
+            except TypeError as error:
+                if task.type.is_detection:
+                    converter = self._alternate_inference_converters[task.title]
+                    annotation_scene_entity = converter.convert_to_annotation(
+                        predictions=postprocessing_results, metadata=metadata
+                    )
+                    # Make sure next time we get it right in one shot
+                    self._inference_converters.update({task.title: converter})
+                else:
+                    raise error
+
+            prediction = Prediction.from_ote(
+                annotation_scene_entity, image_width=width, image_height=height
+            )
+        else:
+            prediction = Prediction(annotations=[])
+
+        # Empty label is not generated by OTE correctly, append it here if there are
+        # no other predictions
+        if len(prediction.annotations) == 0:
+            if self._empty_labels[task.title] is not None:
+                prediction.append(
+                    Annotation(
+                        shape=Rectangle(x=0, y=0, width=width, height=height),
+                        labels=[
+                            ScoredLabel.from_label(
+                                self._empty_labels[task.title], probability=1
+                            )
+                        ],
+                    )
+                )
+
+        # Rotated detection models produce Polygons, convert them here to
+        # RotatedRectangles
+        if task.type == TaskType.ROTATED_DETECTION:
+
+            for annotation in prediction.annotations:
+                if isinstance(annotation.shape, Polygon):
+                    annotation.shape = RotatedRectangle.from_polygon(annotation.shape)
+
+        # Add optional explainability outputs
+        if explain:
+            prediction.feature_vector = repr_vector
+            prediction.active_score = act_score
+            result_medium = ResultMedium(
+                name="saliency map", type="saliency map", data=saliency_map
+            )
+            prediction.maps = [result_medium]
+
+        return prediction
+
+    def _infer_pipeline(self, image: np.ndarray, explain: bool = False) -> Prediction:
+        """
+        Run pre-processing, inference, and post-processing on the input `image`, for
+        all models in the task chain associated with the deployment.
+
+        Note: If `explain=True`, a saliency map, feature vector and active score for
+        the first task in the pipeline will be included in the prediction output
+
+        :param image: Image to run inference on
+        :param explain: True to get additional outputs for model explainability,
+            including saliency maps, the feature vector and active score for the image
+        :return: Inference result
+        """
         previous_labels: Optional[List[Label]] = None
         intermediate_result: Optional[IntermediateInferenceResult] = None
         rois: Optional[List[ROI]] = None
@@ -229,7 +374,7 @@ class Deployment:
 
             # First task in the pipeline generates the initial result and ROIs
             if task.is_trainable and previous_labels is None:
-                task_prediction = self._infer_task(image, task=task)
+                task_prediction = self._infer_task(image, task=task, explain=explain)
                 rois: Optional[List[ROI]] = None
                 if not task.is_global:
                     rois = [
@@ -288,77 +433,6 @@ class Deployment:
                         f"project: Unsupported task type {task.type} found."
                     )
         return intermediate_result.prediction
-
-    def _infer_task(self, image: np.ndarray, task: Task) -> Prediction:
-        """
-        Run pre-processing, inference, and post-processing on the input `image`, for
-        the model associated with the `task`.
-
-        :param image: Image to run inference on
-        :param task: Task to run inference for
-        :return: Inference result
-        """
-        model = self._get_model_for_task(task)
-        preprocessed_image, metadata = model.preprocess(image)
-        inference_results = model.infer(preprocessed_image)
-        postprocessing_results = model.postprocess(inference_results, metadata=metadata)
-        converter = self._inference_converters[task.title]
-
-        width: int = image.shape[1]
-        height: int = image.shape[0]
-
-        try:
-            n_outputs = len(postprocessing_results)
-        except TypeError:
-            n_outputs = 1
-
-        if n_outputs != 0:
-            # The try/except is a workaround to handle different detection inference
-            # results by different ote sdk versions
-            try:
-                annotation_scene_entity = converter.convert_to_annotation(
-                    predictions=postprocessing_results, metadata=metadata
-                )
-            except TypeError as error:
-                if task.type.is_detection:
-                    converter = self._alternate_inference_converters[task.title]
-                    annotation_scene_entity = converter.convert_to_annotation(
-                        predictions=postprocessing_results, metadata=metadata
-                    )
-                    # Make sure next time we get it right in one shot
-                    self._inference_converters.update({task.title: converter})
-                else:
-                    raise error
-
-            prediction = Prediction.from_ote(
-                annotation_scene_entity, image_width=width, image_height=height
-            )
-        else:
-            prediction = Prediction(annotations=[])
-
-        # Empty label is not generated by OTE correctly, append it here if there are
-        # no other predictions
-        if len(prediction.annotations) == 0:
-            if self._empty_labels[task.title] is not None:
-                prediction.append(
-                    Annotation(
-                        shape=Rectangle(x=0, y=0, width=width, height=height),
-                        labels=[
-                            ScoredLabel.from_label(
-                                self._empty_labels[task.title], probability=1
-                            )
-                        ],
-                    )
-                )
-
-        # Rotated detection models produce Polygons, convert them here to
-        # RotatedRectangles
-        if task.type == TaskType.ROTATED_DETECTION:
-
-            for annotation in prediction.annotations:
-                if isinstance(annotation.shape, Polygon):
-                    annotation.shape = RotatedRectangle.from_polygon(annotation.shape)
-        return prediction
 
     def _get_model_for_task(self, task: Task) -> DeployedModel:
         """

--- a/geti_sdk/deployment/deployment.py
+++ b/geti_sdk/deployment/deployment.py
@@ -225,8 +225,8 @@ class Deployment:
     def explain(self, image: np.ndarray) -> Prediction:
         """
         Run inference on an image for the full model chain in the deployment. The
-        resulting prediction will also contain a saliency map, feature vector and
-        active score for the input image.
+        resulting prediction will also contain saliency maps and the feature vector
+        for the input image.
 
         :param image: Image to run inference on, as a numpy array containing the pixel
             data. The image is expected to have dimensions [height x width x channels],
@@ -267,7 +267,7 @@ class Deployment:
         :param image: Image to run inference on
         :param task: Task to run inference for
         :param explain: True to get additional outputs for model explainability,
-            including saliency maps, the feature vector and active score for the image
+            including saliency maps and the feature vector for the image
         :return: Inference result
         """
         model = self._get_model_for_task(task)
@@ -278,9 +278,8 @@ class Deployment:
         # Optional output related to explainability
         saliency_map: Optional[np.ndarray] = None
         repr_vector: Optional[np.ndarray] = None
-        act_score: Optional[float] = None
         if explain:
-            saliency_map, repr_vector, act_score = model.postprocess_explain_outputs(
+            saliency_map, repr_vector = model.postprocess_explain_outputs(
                 inference_results=inference_results, metadata=metadata
             )
         converter = self._inference_converters[task.title]
@@ -343,10 +342,8 @@ class Deployment:
         # Add optional explainability outputs
         if explain:
             prediction.feature_vector = repr_vector
-            prediction.active_score = act_score
-            result_medium = ResultMedium(
-                name="saliency map", type="saliency map", data=saliency_map
-            )
+            result_medium = ResultMedium(name="saliency map", type="saliency map")
+            result_medium.data = saliency_map
             prediction.maps = [result_medium]
 
         return prediction
@@ -361,7 +358,7 @@ class Deployment:
 
         :param image: Image to run inference on
         :param explain: True to get additional outputs for model explainability,
-            including saliency maps, the feature vector and active score for the image
+            including saliency maps and the feature vector for the image
         :return: Inference result
         """
         previous_labels: Optional[List[Label]] = None

--- a/tests/nightly/test_nightly_project.py
+++ b/tests/nightly/test_nightly_project.py
@@ -166,6 +166,10 @@ class TestNightlyProject:
                 visualise_output=False,
             )
 
+            explain_prediction = deployment.explain(image_np)
+            assert explain_prediction.feature_vector is not None
+            assert len(explain_prediction.maps) > 0
+
             online_mask = online_prediction.as_mask(image.media_information)
             local_mask = local_prediction.as_mask(image.media_information)
 

--- a/tests/pre-merge/integration/test_geti.py
+++ b/tests/pre-merge/integration/test_geti.py
@@ -496,6 +496,10 @@ class TestGeti:
             visualise_output=False,
         )
 
+        explain_prediction = deployment.explain(image_np)
+        assert explain_prediction.feature_vector is not None
+        assert len(explain_prediction.maps) > 0
+
         online_mask = online_prediction.as_mask(image.media_information)
         local_mask = local_prediction.as_mask(image.media_information)
 


### PR DESCRIPTION
The method `Deployment.explain()` performs inference and returns a Prediction with a saliency map and feature vector for the input image. When `explain` is used for a task-chain deployment, the saliency map and feature vector are generated only for the first task in the chain.