### PR TITLE
Add score NoneType check in summary function of ProjectStatus

### DIFF
--- a/geti_sdk/data_models/status.py
+++ b/geti_sdk/data_models/status.py
@@ -188,5 +188,6 @@ class ProjectStatus:
             )
             if task.is_training or task.status.progress != -1.0:
                 summary_str += f"      Progress: {task.status.progress:.1f}%\n"
-        summary_str += f"  Latest score: {self.project_performance.score*100:.1f}%\n"
+        if self.project_performance.score is not None:
+            summary_str += f"  Latest score: {self.project_performance.score*100:.1f}%\n"
         return summary_str

--- a/geti_sdk/data_models/status.py
+++ b/geti_sdk/data_models/status.py
@@ -189,5 +189,7 @@ class ProjectStatus:
             if task.is_training or task.status.progress != -1.0:
                 summary_str += f"      Progress: {task.status.progress:.1f}%\n"
         if self.project_performance.score is not None:
-            summary_str += f"  Latest score: {self.project_performance.score*100:.1f}%\n"
+            summary_str += (
+                f"  Latest score: {self.project_performance.score*100:.1f}%\n"
+            )
         return summary_str


### PR DESCRIPTION
The `project_performance.score` of the project in training comes in as NoneType. To avoid the `unsupported operand type(s) for *: 'NoneType' and 'int'` that occurs in this case, added an if statement to check for NoneType.

Related Issue: https://jira.devtools.intel.com/browse/CVS-108934