### PR TITLE
upgrate isort to 5.12.0 to avoid runtime error in pre-commit in python 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
 
   # Import sorting
   - repo: https://github.com/PyCQA/isort
-    rev: 5.8.0
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black"]


### PR DESCRIPTION
This is the fix for the issue #234 