### PR TITLE
Fix for responding to Project Key values in the REST API

### DIFF
--- a/geti_sdk/data_models/project.py
+++ b/geti_sdk/data_models/project.py
@@ -197,6 +197,7 @@ class Project:
     :var datasets: List of datasets belonging to the project
     :var score: Score achieved by the AI assistant for the project
     :var thumbnail: URL at which a thumbnail for the project can be obtained
+    :var storage_info: Storage information for the project can be obtained
     """
 
     _identifier_fields: ClassVar[List[str]] = [
@@ -222,6 +223,7 @@ class Project:
     id: Optional[str] = None
     thumbnail: Optional[str] = None
     creator_id: Optional[str] = None
+    storage_info: Optional[Dict] = None
 
     def get_trainable_tasks(self) -> List[Task]:
         """


### PR DESCRIPTION
Modify to support new project REST API (Geti-1.8.0-on_prem) keys
Related Issue: https://jira.devtools.intel.com/browse/CVS-116394
```
# Refer to web_ui/src/core/projects/dtos/project.interfaces.ts
export interface ProjectDTO extends ProjectCommon {
    creation_time: string;
    id: string;
    name: string;
    datasets: DatasetDTO[];
    pipeline: {
        connections: ConnectionDTO[];
        tasks: TaskDTO[];
    };
    performance: PerformanceDTO;
    thumbnail: string;
    storage_info?: { size: number } | Record<string, never>;  # New added in Geti-1.8.0
}
```