### PR TITLE
Change job monitor functions to use progress bars

### DIFF
--- a/geti_sdk/data_models/job.py
+++ b/geti_sdk/data_models/job.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 import logging
+import re
 from pprint import pformat
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import attr
 
@@ -308,3 +309,33 @@ class Job:
         Return True if the job finished successfully, False otherwise
         """
         return self.status.state == JobState.FINISHED
+
+    def _get_step_information(self) -> Tuple[int, int]:
+        """
+        Return the current step and the total number of steps in the job
+        """
+        status_message = self.status.message
+        step_pattern = re.compile(r"\(Step \d\/\d\)", re.IGNORECASE)
+        results = re.findall(step_pattern, status_message)
+        if len(results) != 1:
+            return 1, 1
+        result_string = results[0].strip("(").strip(")").split("Step")[-1]
+        result_string = result_string.strip()
+        result_nums = result_string.split("/")
+        current = int(result_nums[0])
+        total = int(result_nums[1])
+        return current, total
+
+    @property
+    def total_steps(self) -> int:
+        """
+        Return the total number of steps in the job
+        """
+        return self._get_step_information()[1]
+
+    @property
+    def current_step(self) -> int:
+        """
+        Return the current step for the job
+        """
+        return self._get_step_information()[0]

--- a/geti_sdk/rest_clients/training_client.py
+++ b/geti_sdk/rest_clients/training_client.py
@@ -33,7 +33,7 @@ from geti_sdk.rest_converters import (
     StatusRESTConverter,
 )
 from geti_sdk.utils import get_supported_algorithms
-from geti_sdk.utils.job_helpers import get_job_with_timeout, monitor_jobs
+from geti_sdk.utils.job_helpers import get_job_with_timeout, monitor_job, monitor_jobs
 
 
 class TrainingClient:
@@ -255,6 +255,23 @@ class TrainingClient:
         """
         return monitor_jobs(
             session=self.session, jobs=jobs, timeout=timeout, interval=interval
+        )
+
+    def monitor_job(self, job: Job, timeout: int = 10000, interval: int = 15) -> Job:
+        """
+        Monitor and print the progress of a `job`. Program execution is
+        halted until the job has either finished, failed or was cancelled.
+
+        Progress will be reported in 15s intervals
+
+        :param job: job to monitor
+        :param timeout: Timeout (in seconds) after which to stop the monitoring
+        :param interval: Time interval (in seconds) at which the TrainingClient polls
+            the server to update the status of the jobs. Defaults to 15 seconds
+        :return: job with it's status updated
+        """
+        return monitor_job(
+            session=self.session, job=job, timeout=timeout, interval=interval
         )
 
     def get_jobs_for_task(self, task: Task, running_only: bool = True) -> List[Job]:

--- a/notebooks/007_train_project.ipynb
+++ b/notebooks/007_train_project.ipynb
@@ -216,7 +216,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "training_client.monitor_job(job)"
+    "training_client.monitor_job(job);"
    ]
   },
   {

--- a/notebooks/007_train_project.ipynb
+++ b/notebooks/007_train_project.ipynb
@@ -204,7 +204,7 @@
    "metadata": {},
    "source": [
     "### Monitoring the training process\n",
-    "Using the training_client and the training `job` we just started, we can monitor the training progress on the platform. The `training_client.monitor_jobs()` method can monitor the status of one or several jobs, and will update the job status every 15 seconds. Program execution is halted untill all jobs are completed (either successfully or cancelled/failed). Even if you only want to monitor a single job, be sure to pass it to the monitor_jobs method in a list as shown in the cell below.\n",
+    "Using the training_client and the training `job` we just started, we can monitor the training progress on the platform. The `training_client.monitor_job()` method can monitor the status of a job, and will update the job status every 15 seconds. Program execution is halted untill the job has completed (either successfully or cancelled/failed).\n",
     "\n",
     "> **NOTE**: Because training the task will take quite a bit of time, you may want to interrupt the monitoring at some point. This can be done by selecting the cell in which the monitoring is running and pressing the 'Interrupt the kernel' (solid square) button at the top of the page, or by navigating to the 'Kernel' menu in the top menu bar and selecting 'Interrupt the kernel' there. This will not cancel the job on the platform, it will just abort the job progress monitoring in the notebook."
    ]
@@ -216,7 +216,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "training_client.monitor_jobs([job])"
+    "training_client.monitor_job(job)"
    ]
   },
   {


### PR DESCRIPTION
This PR updates the `TrainingClient().monitor_jobs` function to use progress bars, instead of periodic log output. 

It also adds a `monitor_job` method to the traning client, for monitoring a single job. The functionality is the same as `monitor_jobs`, which can be used for a list of jobs.