### PR TITLE
Decrease verbosity for annotation download

### DIFF
--- a/geti_sdk/rest_clients/annotation_clients/annotation_client.py
+++ b/geti_sdk/rest_clients/annotation_clients/annotation_client.py
@@ -218,6 +218,7 @@ class AnnotationClient(BaseAnnotationClient, Generic[AnnotationReaderType]):
             media_list=images,
             path_to_folder=path_to_folder,
             append_media_uid=append_image_uid,
+            verbose=False,
         )
 
     def download_annotations_for_videos(

--- a/geti_sdk/rest_clients/annotation_clients/base_annotation_client.py
+++ b/geti_sdk/rest_clients/annotation_clients/base_annotation_client.py
@@ -390,20 +390,26 @@ class BaseAnnotationClient:
                     media_item
                 )
                 if annotation_scene is None:
+                    log_msg = (
+                        f"Unable to retrieve latest annotation for {media_name} "
+                        f"{media_item.name}. Skipping this {media_name}"
+                    )
                     if verbose:
-                        logging.info(
-                            f"Unable to retrieve latest annotation for {media_name} "
-                            f"{media_item.name}. Skipping this {media_name}"
-                        )
+                        logging.info(log_msg)
+                    else:
+                        logging.debug(log_msg)
                     skip_count += 1
                     continue
                 kind = annotation_scene.kind
                 if kind != AnnotationKind.ANNOTATION:
+                    log_msg = (
+                        f"Received invalid annotation of kind {kind} for "
+                        f"{media_name} with name{media_item.name}"
+                    )
                     if verbose:
-                        logging.info(
-                            f"Received invalid annotation of kind {kind} for {media_name} "
-                            f"with name{media_item.name}"
-                        )
+                        logging.info(log_msg)
+                    else:
+                        logging.debug(log_msg)
                     skip_count += 1
                     continue
                 export_data = AnnotationRESTConverter.to_dict(annotation_scene)


### PR DESCRIPTION
When downloading all annotations in a project, by default a logging.info message would be generated for every image that does not have an annotation. For bigger projects this would flood the logs. This PR causes those messages to be sent to logging.debug, to reduce the verbosity and prevent cluttering the log