### PR TITLE
Add `Benchmarker` class and demo notebook for inference throughput benchmarking of Geti models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ dist
 .ipynb_checkpoints/
 /notebooks/deployments
 /notebooks/projects
+/notebooks/benchmarks
 
 # Documentation builds
 /docs/build

--- a/geti_sdk/benchmarking/__init__.py
+++ b/geti_sdk/benchmarking/__init__.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+"""
+Introduction
+------------
+
+The `benchmarking` package contains the
+:py:class:`~geti_sdk.benchmarking.benchmarker.Benchmarker` class, which provides
+methods for benchmarking models that are trained and deployed with Intel® Geti™.
+
+For example, benchmarking local inference rates for your project can help in selecting
+the model architecture to use for your project, or in assessing the performance of the
+hardware available for inference.
+
+Module contents
+---------------
+
+.. automodule:: geti_sdk.benchmarking.benchmarker
+   :members:
+   :undoc-members:
+   :show-inheritance:
+"""
+
+from .benchmarker import Benchmarker
+
+__all__ = ["Benchmarker"]

--- a/geti_sdk/benchmarking/benchmarker.py
+++ b/geti_sdk/benchmarking/benchmarker.py
@@ -616,6 +616,26 @@ class Benchmarker:
                     )
 
                 if success:
+                    try:
+                        # Warm-up for the model
+                        deployment.infer(benchmark_frames[0])
+
+                        # Estimate time to completion
+                        t_single_start = time.time()
+                        deployment.infer(benchmark_frames[0])
+                        single_inf_time = time.time() - t_single_start
+                        logging.info(
+                            f"Inference model(s) for deployment `{deployment_folder}` "
+                            f"loaded. Starting benchmark run. Estimated time required: "
+                            f"{repeats*frames*single_inf_time:.0f} seconds"
+                        )
+                    except Exception as e:
+                        success = False
+                        logging.info(
+                            f"Failed to run inference on frame number 0. Marking "
+                            f"benchmark run for deployment `{deployment_folder}` as "
+                            f"failed. Inference failed with error: `{e}`"
+                        )
                     t_start = time.time()
                     for run in range(repeats):
                         for frame in benchmark_frames:
@@ -659,7 +679,7 @@ class Benchmarker:
                     result_row["model 2 score"] = f"{model_scores[1]:.2f}"
                 result_row["success"] = str(int(success))
                 result_row["fps"] = f"{fps:.2f}"
-                result_row["total frames"] = frames * repeats
+                result_row["total frames"] = f"{frames * repeats}"
                 result_row["source"] = deployment_folder
                 result_row.update(get_system_info(device=target_device))
                 results.append(result_row)

--- a/geti_sdk/benchmarking/benchmarker.py
+++ b/geti_sdk/benchmarking/benchmarker.py
@@ -1,0 +1,674 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+import csv
+import itertools
+import logging
+import os
+import time
+from typing import Dict, List, Optional, Sequence, Union
+
+import numpy as np
+from tqdm.auto import tqdm
+from tqdm.contrib.logging import logging_redirect_tqdm
+
+from geti_sdk import Geti
+from geti_sdk.data_models import (
+    Image,
+    Model,
+    OptimizedModel,
+    Performance,
+    Project,
+    Video,
+)
+from geti_sdk.deployment import Deployment
+from geti_sdk.rest_clients import ImageClient, ModelClient, TrainingClient, VideoClient
+
+from .utils import get_system_info, load_benchmark_media, suppress_log_output
+
+
+class Benchmarker:
+    """
+    Initialize and manage benchmarking experiments to measure model throughput on
+    different hardware.
+    """
+
+    def __init__(
+        self,
+        geti: Geti,
+        project: Union[str, Project],
+        precision_levels: Optional[Sequence[str]] = None,
+        models: Optional[Sequence[Model]] = None,
+        algorithms: Optional[Sequence[str]] = None,
+        benchmark_images: Optional[
+            Sequence[Union[Image, np.ndarray, os.PathLike]]
+        ] = None,
+        benchmark_video: Optional[Union[Video, os.PathLike]] = None,
+    ):
+        """
+        Manage benchmarking experiments to measure inference model throughput on
+        different hardware. It allows for quick and easy comparison of inference
+        framerates for different model architectures and precision levels for the
+        specified project.
+
+        The Benchmarker will fetch models from Intel Geti and measure the
+        throughput for local inference for these models. It requires an existing Geti
+        Project to work. The project does not need to be trained yet, but must have
+        sufficient annotations to be able to start training.
+
+        The benchmark can be run on any target device that is supported by OpenVINO.
+        Specifying multiple algorithms and precision levels to include in the
+        benchmark allows for easy comparison of the performance for these models.
+
+        NOTE: For task chain projects, passing `models` or `algorithms` directly in the
+        constructor is not supported. The Benchmarker provides dedicated
+        methods to specify which models or algorithms to use in this case, which can
+        be called after initialization.
+
+        :param geti: Geti instance on which the project to use for benchmarking lives
+        :param project: Project or project name to use for the benchmarking. The
+            project must exist on the specified Geti instance
+        :param precision_levels: List of model precision levels to run the
+            benchmarking for. Throughput will be measured for each precision level
+            in this list. Valid options are ["FP32", "FP16", "INT8"]. Defaults to:
+            ["FP32", "FP16"]
+        :param models: Optional list of base models to use in the benchmarking.
+            Note that this should not be optimized models: The Benchmarker will fetch
+            optimized models in the specified `precision_levels` for the base
+            models specified here
+        :param algorithms: List of algorithm names for which the benchmarking should
+            be performed. If no models are trained for all algorithms in the list,
+            the Benchmarker will trigger training for those algorithms and wait for
+            the training jobs to complete. If neither `models` or `algorithms` are
+            specified, the Benchmarker uses the current active model(s) in the project.
+        :param benchmark_images: Optional list of images to run the benchmarks on. Can
+            be passed as Geti Images, numpy images or filepaths to image files on disk.
+            NOTE: If no images are specified, the benchmark will use a random image
+            or video frame from the project
+        :param benchmark_video: Optional video to use for the benchmarking. Can be
+            passed either as a Geti Video object, or as a filepath to a video file on
+            disk.
+            NOTE: Either `benchmark_video` or `benchmark_images` can be specified, but
+            not both. If neither images nor video is passed, the Benchmarker will
+            pick a random image or video frame from the project to run the benchmark
+            on.
+        """
+        self.geti = geti
+        if isinstance(project, str):
+            project_name = project
+        else:
+            project_name = project.name
+        self.project = geti.get_project(project_name)
+        logging.info(
+            f"Setting up Benchmarker for Intel® Geti™ project `{self.project.name}`."
+        )
+        self._is_single_task = len(self.project.get_trainable_tasks()) == 1
+        if precision_levels is None:
+            precision_levels = ["FP32", "FP16"]
+        self.precision_levels = precision_levels
+        self.model_client = ModelClient(
+            session=geti.session, workspace_id=geti.workspace_id, project=self.project
+        )
+        self.training_client = TrainingClient(
+            session=geti.session, workspace_id=geti.workspace_id, project=self.project
+        )
+
+        self._models: Optional[List[Model]] = None
+        self._task_chain_models: Optional[List[List[Model]]] = None
+        self._algorithms: Optional[List[str]] = None
+        self._task_chain_algorithms: Optional[List[List[str]]] = None
+        self._optimized_models: Optional[List[OptimizedModel]] = None
+        self._task_chain_optimized_models: Optional[List[List[OptimizedModel]]] = None
+        self._deployment_folders: List[os.PathLike] = []
+
+        if not self._is_single_task and (models is not None or algorithms is not None):
+            raise ValueError(
+                "You have specified a task-chain project to be used for benchmarking. "
+                "This does not allow setting `models` or `algorithms` via the "
+                "Benchmark constructor. Please specify which models or algorithms "
+                "should be used in the benchmark using the methods "
+                "`Benchmarker.set_task_chain_models()` or "
+                "`Benchmarker.set_task_chain_algorithms()`. These methods "
+                "can be used after initialization of the Benchmarker. "
+                "Please refer to the method documentation for further guidance."
+            )
+
+        if models is None and algorithms is None:
+            if self._is_single_task:
+                logging.info(
+                    "No `models` or `algorithms` were specified, using current active "
+                    "models in the project."
+                )
+            else:
+                logging.info(
+                    "Models or algorithms to benchmark for a task chain project can "
+                    "be specified by calling the `Benchmarker.set_task_chain_models()`"
+                    " or `Benchmarker.set_task_chain_algorithms()` methods. If these "
+                    "methods are not called, the benchmark will be set up using the "
+                    "current active models."
+                )
+            models = self.model_client.get_all_active_models()
+            if len(models) == 0:
+                raise ValueError(
+                    "No trained models were found in the project, please either "
+                    "train a model first or specify an algorithm to train."
+                )
+            algorithms: List[str] = []
+            for model in models:
+                task = self.model_client.get_task_for_model(model=model)
+                if self._is_single_task:
+                    logging.info(
+                        f"Found active model `{model.name}` for task `{task.title}`"
+                    )
+                algorithms.append(model.architecture)
+            if self._is_single_task:
+                self._models = models
+                self._algorithms = algorithms
+            else:
+                self._task_chain_models = [[model] for model in models]
+                self._task_chain_algorithms = [[algo] for algo in algorithms]
+            self._are_models_specified = True
+
+        elif models is not None and algorithms is not None:
+            raise ValueError(
+                "Either `models` or `algorithms` could be specified, but not both."
+            )
+        elif models is not None and algorithms is None:
+            self._models = models
+            self._are_models_specified = True
+            self._algorithms = [model.architecture for model in models]
+        elif models is None and algorithms is not None:
+            self._models = None
+            self._are_models_specified = False
+            self._algorithms = algorithms
+
+        self.images = None
+        self.video = None
+        if benchmark_video is not None and benchmark_images is not None:
+            raise ValueError(
+                "Please specify either `benchmark_video` or `benchmark_images`, but "
+                "not both."
+            )
+        elif benchmark_images is not None:
+            self.images = benchmark_images
+        elif benchmark_video is not None:
+            self.video = benchmark_video
+        else:
+            image_client = ImageClient(
+                session=geti.session,
+                workspace_id=geti.workspace_id,
+                project=self.project,
+            )
+            images = image_client.get_all_images()
+            if len(images) > 0:
+                self.images = [images[0]]
+            else:
+                video_client = VideoClient(
+                    session=geti.session,
+                    workspace_id=geti.workspace_id,
+                    project=self.project,
+                )
+                videos = video_client.get_all_videos()
+                if len(videos) > 0:
+                    self.video = videos[0]
+                else:
+                    raise ValueError(
+                        "No benchmark images or video was specified, and no media "
+                        "could be found in the project. Unable to proceed, please "
+                        "specify either images or a video to run the benchmark on."
+                    )
+
+    def set_task_chain_models(
+        self, models_task_1: Sequence[Model], models_task_2: Sequence[Model]
+    ):
+        """
+        Set the models to be used in the benchmark for a task-chain project. The
+        benchmarking will run for all possible combinations of models for task 1
+        and task 2.
+
+        :param models_task_1: Models to use for task #1
+        :param models_task_2: Models to use for task #2
+        """
+        if self._is_single_task:
+            logging.warning(
+                "Method `set_task_chain_models` was called for a non-task-chain "
+                "project. This has no effect."
+            )
+            return
+        self._task_chain_models = [
+            list(pair) for pair in itertools.product(models_task_1, models_task_2)
+        ]
+        self._are_models_specified = True
+        self._task_chain_algorithms = [
+            [model.architecture for model in pair] for pair in self._task_chain_models
+        ]
+        logging.info(
+            f"Task chain models set. Found a total of "
+            f"{len(self._task_chain_models)} possible combinations to benchmark"
+        )
+
+    def set_task_chain_algorithms(
+        self, algorithms_task_1: Sequence[str], algorithms_task_2: Sequence[str]
+    ):
+        """
+        Set the algorithms to be used in the benchmark for a task-chain project. The
+        benchmarking will run for all possible combinations of algorithms for task 1
+        and task 2.
+
+        Note that upon benchmark initialization, the Benchmarker will check if
+        trained models are available for all algorithms specified
+
+        :param algorithms_task_1: Algorithms to use for task #1
+        :param algorithms_task_2: Algorithms to use for task #2
+        """
+        if self._is_single_task:
+            logging.warning(
+                "Method `set_task_chain_algorithms` was called for a non-task-chain "
+                "project. This has no effect."
+            )
+            return
+        self._task_chain_algorithms = [
+            list(pair)
+            for pair in itertools.product(algorithms_task_1, algorithms_task_2)
+        ]
+        self._are_models_specified = False
+        self._task_chain_models = None
+        logging.info(
+            f"Task chain algorithms set. Found a total of "
+            f"{len(self._task_chain_algorithms)} possible algorithm combinations "
+            f"to benchmark"
+        )
+
+    @property
+    def models(self) -> Union[List[Model], List[List[Model]]]:
+        """
+        Return the models to be used in the benchmark.
+        """
+        if self._are_models_specified:
+            if self._is_single_task:
+                return self._models
+            return self._task_chain_models
+        raise ValueError(
+            "Unable to access models, no benchmark models have been specified yet."
+        )
+
+    @property
+    def algorithms(self) -> Union[List[str], List[List[str]]]:
+        """
+        Return the algorithm names to be used in the benchmark
+        """
+        if self._is_single_task:
+            return self._algorithms
+        return self._task_chain_algorithms
+
+    @property
+    def optimized_models(
+        self,
+    ) -> Union[List[OptimizedModel], List[List[OptimizedModel]]]:
+        """
+        Return the optimized models to be used in deployments for the benchmark
+        """
+        if self._is_single_task and self._optimized_models is not None:
+            return self._optimized_models
+        elif not self._is_single_task and self._task_chain_optimized_models is not None:
+            return self._task_chain_optimized_models
+        raise ValueError(
+            "Optimized models have not been assigned yet. Please initialize the "
+            "benchmarker first using the `initialize_benchmark` method."
+        )
+
+    def _train_model_for_algorithm(self, task_index: int, algorithm_name: str) -> Model:
+        """
+        Train a model for the specified task and algorithm
+
+        :param task_index: Index of the task for which to train the model
+        :param algorithm_name: Name of the algorithm to use
+        :return: Model object, representing the trained model
+        """
+        algos = self.training_client.get_algorithms_for_task(task_index)
+        algo = algos.get_by_name(algorithm_name)
+        job = self.training_client.train_task(task_index, algorithm=algo)
+        job = self.training_client.monitor_job(job=job)
+        return self.model_client.get_model_for_job(job)
+
+    def _optimize_model_for_algorithm(
+        self, model: Model, precision: str = "INT8"
+    ) -> OptimizedModel:
+        """
+        Optimize a `model` with the given `precision`.
+
+        :param model: Base model to optimize
+        :param precision: Precision to use for the optimization
+        :return: OptimizedModel object, representing the optimized model
+        """
+        optimization_type_map = {"INT8": "pot"}
+        job = self.model_client.optimize_model(
+            model=model, optimization_type=optimization_type_map[precision]
+        )
+        self.model_client.monitor_job(job)
+        updated_model = self.model_client.update_model_detail(model)
+        return updated_model.get_optimized_model(
+            precision=precision, optimization_type="openvino"
+        )
+
+    def prepare_benchmark(self, working_directory: os.PathLike = "."):
+        """
+        Prepare the benchmarking experiments. This involves:
+
+            1. Ensuring that all required models are available, i.e. that all
+                specified algorithms have a trained model in the Geti project. If
+                not, training jobs will be started and awaited.
+            2. Ensuring that for each model, optimized models with the required
+                quantization level are available. If not, optimization jobs will
+                be started and awaited.
+            3. Creating and downloading deployments for all models to benchmark.
+
+        :param working_directory: Output directory to which the deployments for the
+            benchmark will be saved.
+        """
+        logging.info("Preparing benchmark experiments.")
+        # First, check if model training is required. This happens when
+        # algorithms are specified, but not all algorithms may have a model
+        # trained already.
+        if not self._are_models_specified:
+            if self._is_single_task:
+                logging.info(
+                    f"Checking model availability for {len(self.algorithms)} "
+                    f"different algorithms: {self.algorithms}."
+                )
+                models: List[Model] = []
+                for algorithm_name in self.algorithms:
+                    model = self.model_client.get_latest_model_by_algo_name(
+                        algorithm_name
+                    )
+                    if model is None:
+                        logging.info(
+                            f"No model found in project for algorithm "
+                            f"{algorithm_name}, requesting model training"
+                        )
+                        model = self._train_model_for_algorithm(
+                            task_index=0, algorithm_name=algorithm_name
+                        )
+                    models.append(model)
+                self._models = models
+            else:
+                logging.info(
+                    f"Checking model availability for {len(self.algorithms)} "
+                    f"different pairs of algorithms."
+                )
+                models: List[List[Model]] = []
+                for algo_pair in self.algorithms:
+                    model_pair: List[Model] = []
+                    for task_index, algorithm_name in enumerate(algo_pair):
+                        model = self.model_client.get_latest_model_by_algo_name(
+                            algorithm_name
+                        )
+                        if model is None:
+                            model = self._train_model_for_algorithm(
+                                task_index=task_index, algorithm_name=algorithm_name
+                            )
+                        model_pair.append(model)
+                    models.append(model_pair)
+                self._task_chain_models = models
+            self._are_models_specified = True
+        logging.info("All required base models are available")
+        # Then, check if model optimization is required. Create a list of
+        # optimized models for which deployments should be created.
+        if self._is_single_task:
+            logging.info(
+                f"Checking optimized model availability for {len(self.models)} "
+                f"different models and quantization levels: {self.precision_levels}"
+            )
+            optimized_models: List[OptimizedModel] = []
+            for model in self.models:
+                for precision in self.precision_levels:
+                    opt_model = model.get_optimized_model(
+                        precision=precision, optimization_type="openvino"
+                    )
+                    if opt_model is None:
+                        logging.info(
+                            f"No optimized model with quantization level {precision} "
+                            f"found for model {model.name}, requesting model "
+                            f"optimization."
+                        )
+                        opt_model = self._optimize_model_for_algorithm(
+                            model=model, precision=precision
+                        )
+                    optimized_models.append(opt_model)
+            self._optimized_models = optimized_models
+        else:
+            logging.info(
+                f"Checking optimized model availability for {len(self.models)} "
+                f"different model pairs and quantization levels: "
+                f"{self.precision_levels}"
+            )
+            optimized_models: List[List[OptimizedModel]] = []
+            for model_pair in self.models:
+                for precision in self.precision_levels:
+                    opt_model_pair: List[OptimizedModel] = []
+                    for model in model_pair:
+                        # Update model info, to take into account any
+                        # optimizations made during loop execution
+                        model = self.model_client.update_model_detail(model=model)
+                        opt_model = model.get_optimized_model(
+                            precision=precision, optimization_type="openvino"
+                        )
+                        if opt_model is None:
+                            logging.info(
+                                f"No optimized model with quantization level {precision} "
+                                f"found for model {model.name}, requesting model "
+                                f"optimization."
+                            )
+                            opt_model = self._optimize_model_for_algorithm(
+                                model=model, precision=precision
+                            )
+                        opt_model_pair.append(opt_model)
+                    optimized_models.append(opt_model_pair)
+            self._task_chain_optimized_models = optimized_models
+        logging.info("All required optimized models are available")
+
+        # Next up, create deployments for all optimized models
+        os.makedirs(working_directory, exist_ok=True)
+        logging.info(
+            f"Creating {len(self.optimized_models)} deployments to benchmark. Saving "
+            f"deployment data to folder: `{working_directory}`"
+        )
+        with logging_redirect_tqdm(tqdm_class=tqdm):
+            for index, opt_models in tqdm(
+                enumerate(self.optimized_models),
+                total=len(self.optimized_models),
+                desc="Creating deployments",
+            ):
+                if isinstance(opt_models, OptimizedModel):
+                    opt_models = [opt_models]
+                output_folder = os.path.join(working_directory, f"deployment_{index}")
+                with suppress_log_output():
+                    self.geti.deploy_project(
+                        project_name=self.project.name,
+                        output_folder=output_folder,
+                        models=opt_models,
+                    )
+                    self._deployment_folders.append(output_folder)
+        logging.info("Deployments created. Benchmark initialization complete.")
+
+    def initialize_from_folder(self, target_folder: os.PathLike = "."):
+        """
+        Initialize the Benchmarker from a folder containing deployments. This method
+        checks that any directory inside the `target_folder` contains a valid
+        deployment for the project assigned to this Benchmarker.
+
+        :param target_folder: Directory containing the model deployments that should
+            be used in the Benchmarking.
+        """
+        logging.info(f"Initializing Benchmarker from folder `{target_folder}`")
+        if len(self._deployment_folders) != 0:
+            raise ValueError(
+                "The Benchmarker appears to be already initialized. Unable to "
+                "continue."
+            )
+        for object in os.listdir(target_folder):
+            object_path = os.path.join(target_folder, object)
+            if os.path.isfile(object_path):
+                continue
+            try:
+                deployment = Deployment.from_folder(path_to_folder=object_path)
+            except ValueError:
+                logging.info(
+                    f"Directory {object_path} does not contain a valid Deployment, "
+                    f"skipping..."
+                )
+                continue
+            if deployment.project.name != self.project.name:
+                raise ValueError(
+                    f"Deployment at path `{object_path}` was created for project "
+                    f"{deployment.project.name}, yet the Benchmarker was set up for "
+                    f"project {self.project.name}. Unable to initialize. Please use "
+                    f"only deployments created for project `{self.project.name}`"
+                )
+            self._deployment_folders.append(object_path)
+
+        if len(self._deployment_folders) != 0:
+            logging.info(
+                f"Benchmarker was initialized from folder. {len(self._deployment_folders)} "
+                f"valid deployment folders were found."
+            )
+
+    def run_throughput_benchmark(
+        self,
+        working_directory: os.PathLike = ".",
+        results_filename: str = "results",
+        target_device: str = "CPU",
+        frames: int = 200,
+        repeats: int = 3,
+    ) -> List[Dict[str, str]]:
+        """
+        Run the benchmark experiment.
+
+        :param working_directory: Directory in which the deployments that should be
+            benchmarked are stored. All output will be saved to this directory.
+        :param results_filename: Name of the file to which the results will be saved.
+            File extension should not be included, the results will always be saved as
+            a `.csv` file. Defaults to `results.csv`. The results file will be created
+            within the `working_directory`
+        :param target_device: Device to run the inference models on, for example "CPU"
+            or "GPU". Defaults to "CPU".
+        :param frames: Number of frames/images to infer in order to calculate
+            fps
+        :param repeats: Number of times to repeat the benchmark runs. FPS will be
+            averaged over the runs.
+        """
+        if len(self._deployment_folders) == 0:
+            raise ValueError(
+                "Benchmarker does not contain any deployments to benchmark yet! Please "
+                "prepare the deployments first using either the "
+                "`Benchmarker.prepare_benchmark()` or "
+                "`Benchmarker.initialize_from_folder()` methods."
+            )
+        logging.info("Starting throughput benchmark experiments.")
+
+        logging.info(
+            f"The Benchmarker will run for {len(self._deployment_folders)} deployments"
+        )
+
+        logging.info("Loading benchmark media")
+        benchmark_frames = load_benchmark_media(
+            session=self.geti.session,
+            images=self.images,
+            video=self.video,
+            frames=frames,
+        )
+
+        results_file = os.path.join(working_directory, f"{results_filename}.csv")
+        logging.info(f"Writing results to `{results_file}`")
+
+        logging.info(
+            f"Benchmarking inference rate for synchronous inference on {frames} frames "
+            f"with {repeats} repeats"
+        )
+        with logging_redirect_tqdm(tqdm_class=tqdm), open(
+            results_file, "w", newline=""
+        ) as csvfile:
+            results: List[Dict[str, str]] = []
+            for index, deployment_folder in enumerate(
+                tqdm(self._deployment_folders, desc="Benchmarking")
+            ):
+                success = True
+                deployment = Deployment.from_folder(deployment_folder)
+                try:
+                    with suppress_log_output():
+                        deployment.load_inference_models(device=target_device)
+                except Exception as e:
+                    success = False
+                    logging.info(
+                        f"Failed to load inference models for deployment at path: "
+                        f"`{deployment_folder}`, with error: {e}. Marking benchmark "
+                        f"run for the deployment as failed"
+                    )
+
+                if success:
+                    t_start = time.time()
+                    for run in range(repeats):
+                        for frame in benchmark_frames:
+                            try:
+                                deployment.infer(frame)
+                            except Exception as e:
+                                success = False
+                                logging.info(
+                                    f"Failed to run inference on frame number "
+                                    f"{benchmark_frames.index(frame)}. Marking "
+                                    f"benchmark run for deployment "
+                                    f"`{deployment_folder}` as failed. Inference "
+                                    f"failed with error: `{e}`"
+                                )
+                    t_elapsed = time.time() - t_start
+                    fps = frames * repeats / t_elapsed
+                else:
+                    fps = 0
+
+                model_scores = []
+                for om in deployment.models:
+                    if isinstance(om.performance, Performance):
+                        score = om.performance.score
+                    elif isinstance(om.performance, dict):
+                        score = om.performance.get("score", -1)
+                    else:
+                        score = -1
+                    model_scores.append(score)
+
+                # Update result list
+                result_row: Dict[str, str] = {}
+                result_row["name"] = f"Deployment {index}"
+                result_row["project_name"] = self.project.name
+                result_row["target_device"] = target_device
+                result_row["task 1"] = self.project.get_trainable_tasks()[0].title
+                result_row["model 1"] = deployment.models[0].name
+                result_row["model 1 score"] = f"{model_scores[0]:.2f}"
+                if not self._is_single_task:
+                    result_row["task 2"] = self.project.get_trainable_tasks()[1].title
+                    result_row["model 2"] = deployment.models[1].name
+                    result_row["model 2 score"] = f"{model_scores[1]:.2f}"
+                result_row["success"] = str(int(success))
+                result_row["fps"] = f"{fps:.2f}"
+                result_row["total frames"] = frames * repeats
+                result_row["source"] = deployment_folder
+                result_row.update(get_system_info(device=target_device))
+                results.append(result_row)
+
+                # Write results to file
+                if index == 0:
+                    fieldnames = list(result_row.keys())
+                    writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+                    writer.writeheader()
+                writer.writerow(result_row)
+
+        return results

--- a/geti_sdk/benchmarking/utils.py
+++ b/geti_sdk/benchmarking/utils.py
@@ -1,0 +1,209 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+import logging
+import os
+import platform
+import sys
+from contextlib import contextmanager
+from logging.handlers import MemoryHandler
+from typing import Dict, List, Optional, Sequence, Union
+
+import cv2
+import numpy as np
+from openvino.runtime import get_version
+
+import geti_sdk
+from geti_sdk.data_models import Image, Video
+from geti_sdk.geti import DEFAULT_LOG_FORMAT
+from geti_sdk.http_session import GetiSession
+
+try:
+    # Updated OpenVINO API, from v2023.2.0
+    from openvino.core import Core
+    from openvino.properties import device as ov_device
+except ImportError:
+    # The old API
+    from openvino.runtime import Core
+    from openvino.runtime.properties import device as ov_device
+
+
+def get_system_info(device: str = "CPU") -> Dict[str, str]:
+    """
+    Retrieve relevant information about the system
+
+    :param device: Hardware device to retrieve the info for, for example "CPU", "GPU",
+        etc. Defaults to "CPU".
+    :return: Dictionary containing system information
+        - Operating system
+        - Processor name
+        - Python version
+        - Geti SDK version
+        - OpenVINO version
+    """
+    ov_core = Core()
+    try:
+        device_info = ov_core.get_property(
+            device_name=device, property=ov_device.full_name()
+        )
+    except RuntimeError as e:
+        logging.warning(
+            f"Unable to retrieve device info for device `{device}`. Failed with "
+            f"error: `{e}`"
+        )
+        device_info = device
+    info: Dict[str, str] = {}
+    info["operating_system"] = platform.system()
+    info["device_info"] = device_info
+    info["python"] = platform.python_version()
+    info["geti-sdk"] = geti_sdk.__version__
+    info["openvino"] = get_version()
+    return info
+
+
+def load_benchmark_media(
+    session: GetiSession,
+    images: Optional[Sequence[Union[Image, np.ndarray, os.PathLike]]] = None,
+    video: Optional[Union[Video, os.PathLike]] = None,
+    frames: int = 200,
+) -> List[np.ndarray]:
+    """
+    Load and standardize a list of media. This method will return a list of numpy 2D
+    arrays containing the frame data. The list will contain exactly `frames` elements.
+
+    Either `video` or `images` should be specified, but not both.
+
+    If the list of `images` contains less than `frames` elements, the first image in
+    the list will be used to pad the list up to a length of `frames`.
+    Similarly, if the `video` contains less frames than what is specified in `frames`,
+    the first frame of the video will be used as padding.
+
+    :param session: GetiSession pointing to the Geti server that can be used to
+        retrieve the media data
+    :param images: List of either:
+        - Geti Image objects, identifying images on the Geti server
+        - numpy 2D arrays, containing the image data
+        - PathLike objects, pointing to the filepaths of images to load
+    :param video: Either a Geti Video object or a filepath pointing to a video file on
+        disk.
+        NOTE: Either `video` or `images` should be specified, but not both
+    :param frames: Number of frames to return
+    :return: List of 2D arrays containing image/frame data. The returned list has a
+        length of exactly `frames`.
+    """
+    if video is not None and images is not None:
+        raise ValueError("Please specify either `video` or `images`, but not both.")
+    if frames > 1000:
+        logging.warning(
+            f"You have specified {frames} to be loaded into memory. This may cause "
+            f"out of memory problems on systems with constrained resources. Please "
+            f"consider reducing the number of frames to load"
+        )
+    loaded_frames: List[np.ndarray] = []
+    if images is not None:
+        if len(images) < frames:
+            # Fill the list of images up to `frames` using the first image
+            images += [images[0]] * (frames - len(images))
+        elif len(images) > frames:
+            # Select only the first `frames` images
+            images = images[0:frames]
+        for image_object in images:
+            if isinstance(image_object, Image):
+                image_np = image_object.get_data(session=session)
+                loaded_frames.append(image_np)
+            elif isinstance(image_object, np.ndarray):
+                loaded_frames.append(image_object)
+            elif isinstance(image_object, (os.PathLike, str)):
+                image_cv = cv2.imread(image_object)
+                image_cv = cv2.cvtColor(image_cv, cv2.COLOR_BGR2RGB)
+                loaded_frames.append(image_cv)
+            else:
+                raise TypeError(
+                    f"Encountered invalid image object of type {type(image_object)}. "
+                    f"Please pass either Geti Image objects, numpy arrays with image "
+                    f"data or image filepaths."
+                )
+    elif video is not None:
+        video_data_path: str
+        if isinstance(video, Video):
+            video_data_path = video.get_data(session=session)
+        elif isinstance(video, os.PathLike):
+            video_data_path = video
+        else:
+            raise TypeError(
+                f"Encountered invalid video object of type {video.type}. Please "
+                f"pass either a Geti Video object or a filepath to a video on disk."
+            )
+        cap = cv2.VideoCapture(video_data_path)
+
+        if cap is None or not cap.isOpened():
+            raise ValueError(f"Unable to read video from {video_data_path}")
+
+        frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        while cap.isOpened() and len(loaded_frames) < frame_count:
+            ret, frame = cap.read()
+            if ret is True:
+                rgb_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                loaded_frames.append(rgb_frame)
+            else:
+                break
+        cap.release()
+        if len(loaded_frames) < frame_count:
+            # Pad with first frame if the video was too short
+            loaded_frames += [loaded_frames[0]] * (frames - len(loaded_frames))
+    return loaded_frames
+
+
+@contextmanager
+def suppress_log_output(
+    target_logger: Optional[logging.Logger] = None,
+    target_handler: Optional[logging.Handler] = None,
+):
+    """
+    Context manager to temporarily capture and suppress log output.
+    All logging calls made in the context will be redirected to memory,
+    unless ERROR level message are logged. In that case the output will be sent to
+    the `target_handler`.
+
+    :param target_logger: Optional Logger of which the output should be captured
+    :param target_handler: Optional Handler that should be used in case of ERROR log
+        message
+    """
+    if target_logger is None:
+        target_logger = logging.getLogger()
+
+    if target_handler is None:
+        target_handler = logging.StreamHandler(stream=sys.stdout)
+    formatter = logging.Formatter(DEFAULT_LOG_FORMAT)
+    target_handler.setFormatter(formatter)
+
+    memory_handler = MemoryHandler(
+        capacity=1000, flushLevel=logging.ERROR, target=target_handler
+    )
+
+    original_handlers = target_logger.handlers
+    for handler in original_handlers:
+        target_logger.removeHandler(handler)
+    target_logger.addHandler(memory_handler)
+
+    try:
+        yield target_logger
+    except Exception:
+        target_logger.exception("Error in `suppress_log_output`")
+        raise
+    finally:
+        # Flush the memory handler and reinstate the original log handlers
+        super(MemoryHandler, memory_handler).flush()
+        target_logger.removeHandler(memory_handler)
+        for handler in original_handlers:
+            target_logger.addHandler(handler)

--- a/geti_sdk/data_models/model.py
+++ b/geti_sdk/data_models/model.py
@@ -270,32 +270,61 @@ class Model(BaseModel):
         return cls.from_dict(model_dict=model_dict)
 
     def get_optimized_model(
-        self, optimization_type: str, require_xai: bool = False
+        self,
+        optimization_type: Optional[str] = None,
+        precision: Optional[str] = None,
+        require_xai: bool = False,
     ) -> Optional[OptimizedModel]:
         """
-        Return the OptimizedModel of the specified `optimization_type`. The following
-        optimization types are supported: 'nncf', 'pot', 'onnx', 'mo' (case insensitive).
+        Return the OptimizedModel of the specified `optimization_type` or `precision`.
+        The following optimization types are supported: 'nncf', 'pot', 'onnx', 'mo',
+        `openvino`
+        (case insensitive). The supported precision levels are `FP32`, `FP16`, `INT8`.
+        Precision, optimization type or both can be specified.
 
         :param optimization_type: Optimization type for which to return the model
+        :param precision: Precision level for which to return the model. Can be `FP32`,
+            `FP16` or `INT8`
         :param require_xai: If True, only include models that have an XAI head for
             saliency map generation. Defaults to False
         :return: OptimizedModel object representing the optimized model
         """
-        capitalized_ot = optimization_type.upper()
-        allowed_types = [item.name for item in OptimizationType]
-        if capitalized_ot not in allowed_types:
-            raise ValueError(
-                f"Invalid optimization type passed, supported values are "
-                f"{allowed_types}"
-            )
-        optim_type = OptimizationType(capitalized_ot)
-        optimized_models = [
-            model
-            for model in self.optimized_models
-            if model.optimization_type == optim_type
-        ]
+        if optimization_type is None and precision is None:
+            raise ValueError("Please specify optimization_type or precision, or both")
+        optimized_models: List[OptimizedModel] = None
+        if optimization_type is not None:
+            capitalized_ot = optimization_type.upper()
+            if capitalized_ot == "OPENVINO":
+                optimized_models = [
+                    model for model in self.optimized_models if "ONNX" not in model.name
+                ]
+            else:
+                allowed_types = [item.name for item in OptimizationType]
+                if capitalized_ot not in allowed_types:
+                    raise ValueError(
+                        f"Invalid optimization type passed, supported values are "
+                        f"{allowed_types} or `openvino`"
+                    )
+                optim_type = OptimizationType(capitalized_ot)
+                optimized_models = [
+                    model
+                    for model in self.optimized_models
+                    if model.optimization_type == optim_type
+                ]
+
+        if precision is not None:
+            if optimized_models is None:
+                models_to_search = self.optimized_models
+            else:
+                models_to_search = optimized_models
+            optimized_models = [
+                model for model in models_to_search if precision in model.name
+            ]
+
         if len(optimized_models) == 0:
-            logging.info(f"No optimized model of type {optim_type} was found.")
+            logging.info(
+                "No optimized model meeting the optimization criteria was found."
+            )
             return None
         elif len(optimized_models) == 1:
             if not require_xai:

--- a/geti_sdk/rest_clients/deployment_client.py
+++ b/geti_sdk/rest_clients/deployment_client.py
@@ -379,6 +379,7 @@ class DeploymentClient:
         stop_polling = False
         logging.info("Waiting for the deployment to be created...")
         while not stop_polling:
+            time.sleep(1)
             code_deployment = self._get_deployment_status(code_deployment.id)
             if code_deployment.state == DeploymentState.DONE:
                 stop_polling = True
@@ -387,7 +388,6 @@ class DeploymentClient:
                     f"The Intel® Geti™ server failed to create deployment for "
                     f"project '{self.project.name}'."
                 )
-            time.sleep(1)
 
         # Fetch the deployment package
         deployment = self._fetch_deployment(deployment_id=code_deployment.id)

--- a/notebooks/011_benchmarking_models.ipynb
+++ b/notebooks/011_benchmarking_models.ipynb
@@ -1,0 +1,267 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c50e16b1-86a2-42f9-84be-845f06bcbb60",
+   "metadata": {},
+   "source": [
+    "# Geti model benchmarking\n",
+    "\n",
+    "This notebook shows how to measure and compare the inference rates on your local hardware for the various algorithms available in a Geti project. The Geti SDK provides a `Benchmarker` class, that allows to quickly set up a series of benchmarking experiments for a specific project. This allows making a comparison of the framerates that can be achieved using deployed models of different algorithms. As such, it can help to select a suitable architecture for model deployment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fbb21e7-b203-467d-b136-3a8f6a5879b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# As usual we will connect to the platform first, using the server details from the .env file\n",
+    "\n",
+    "from geti_sdk import Geti\n",
+    "from geti_sdk.utils import get_server_details_from_env\n",
+    "\n",
+    "geti_server_configuration = get_server_details_from_env()\n",
+    "\n",
+    "geti = Geti(server_config=geti_server_configuration)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f476b474-22a2-4c78-9ccb-3b9166c36264",
+   "metadata": {},
+   "source": [
+    "## Selecting a project\n",
+    "The `Benchmarker` can run experiments for a single project. It can be either a single task or a task chain project. As an example, we'll pick the `COCO animal detection demo` project that we created in [notebook 002](002_create_project_from_dataset.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c5670de-61e8-44d9-95dd-dd0a4b88e606",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PROJECT_NAME = \"COCO animal detection demo\"\n",
+    "project = geti.get_project(PROJECT_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "624baa98-d183-430e-99aa-6f1d862d5b6a",
+   "metadata": {},
+   "source": [
+    "## Setting up the Benchmarker\n",
+    "Now that we know which project to pick, we can initialize the `Benchmarker`. We need to decide on a couple of things:\n",
+    "1. Which algorithms to benchmark\n",
+    "2. What media to use for benchmarking\n",
+    "3. The precision levels of the models we want to benchmark (i.e. FP32, FP16, INT8)\n",
+    "\n",
+    "### Algorithms\n",
+    "For the algorithms, let's use 3 different algorithms that are available for the project that we selected. The `COCO animal detection demo` project is a single task project, with a Detection task. The `algorithms_to_benchmark` variable holds the names of the different Detection algorithms that we can choose in Geti: `SSD`, `YOLOX` and `MobileNetV2-ATSS`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83641870-794d-4cbd-a108-2197d319e163",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "algorithms_to_benchmark = [\"MobileNetV2-ATSS\", \"SSD\", \"YOLOX\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a9fd76f-4d63-4a32-8eaa-dd7affd31357",
+   "metadata": {},
+   "source": [
+    "### Media\n",
+    "The experiments can run on either images or a video. There are various options to specify the input media: You can supply a list of image filepaths, a path to a video, a list of Geti `Image` objects or numpy arrays, or a Geti `Video` object. In this case, we'll simply use all images that are already in the project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7988bff8-fc2b-48f0-84c6-5f26b945f3c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geti_sdk.rest_clients import ImageClient\n",
+    "\n",
+    "image_client = ImageClient(\n",
+    "    session=geti.session, workspace_id=geti.workspace_id, project=project\n",
+    ")\n",
+    "images = image_client.get_all_images()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0c22b75-e229-40e2-b42c-f541e8694d70",
+   "metadata": {},
+   "source": [
+    "### Precision levels\n",
+    "Geti allows deploying models with different precision levels. Typically, deploying a model with `INT8` precision results in a considerable increase in throughput compared to running an `FP32` or even `FP16` model. Using the `Benchmarker`, we can measure the inference framerate for each of these precision levels and quantify the difference. We simply have to pass a `precision_levels` variable that contains the model precisions we want to deploy and measure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6c3a26b-126e-454e-befe-38f3d477c328",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "precision_levels = [\"FP32\", \"FP16\", \"INT8\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ad7dcc8-9ec7-4212-82c1-13a5d93960e0",
+   "metadata": {},
+   "source": [
+    "### Benchmarker initialization\n",
+    "With the project, algorithms, media and precision levels sorted out, we can initialize the Benchmarker."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8506f981-cbb9-41c4-8751-cba07592dad4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geti_sdk.benchmarking import Benchmarker\n",
+    "\n",
+    "benchmarker = Benchmarker(\n",
+    "    geti=geti,\n",
+    "    project=project,\n",
+    "    algorithms=algorithms_to_benchmark,\n",
+    "    precision_levels=precision_levels,\n",
+    "    benchmark_images=images,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fecd6ede-f3f1-4705-8aa0-4eb3ff2b16ed",
+   "metadata": {},
+   "source": [
+    "## Preparing the Intel® Geti™ project to run the benchmark\n",
+    "Now that the `Benchmarker` is initialized, we need to make sure that all the algorithms that we'd like to benchmark have a model trained in the project. To do so, the Benchmarker provides a `prepare_benchmark` method that we can call. If we call it, the method will make sure of three things:\n",
+    "1. It will check if every algorithm we want to benchmark has a trained model in the project. If not, it will start model training and will wait for it to complete\n",
+    "2. It will check if for every trained model that we want to benchmark an optimized model is available in the specified precision levels. If not, it will trigger model optimiziation in the required precision levels and wait for it to complete\n",
+    "3. It will create and download deployments for all the specified algorithms and precision levels.\n",
+    "\n",
+    "When calling the `prepare_benchmark` method, we just have to pass a path to a directory on the local disk. The method will save the deployments that it creates to this folder.\n",
+    "\n",
+    "> NOTE: Preparing the benchmark may take some time, especially if not all algorithms have a model trained. In that case we have to wait for model training to complete. Please run the cell below and wait for all jobs to complete. Progress will be reported as the training and optimization advances."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0463e42c-e9ea-42a0-9b2c-19c9ccd23cd0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "benchmark_folder = os.path.join(\"benchmarks\", PROJECT_NAME)\n",
+    "benchmarker.prepare_benchmark(working_directory=benchmark_folder)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fbc52522-1cde-4c7f-86a1-366b31dc7a8a",
+   "metadata": {},
+   "source": [
+    "## Running the benchmark\n",
+    "At this point all models are trained, optimized and deployed! This means that the benchmark is ready to go. You can run the benchmark by calling the `run_throughput_benchmark` method that the `Benchmarker` provides. It accepts the following arguments:\n",
+    "\n",
+    "- `working_directory`: The folder in which the deployments are stored that should be benchmarked. Benchmarking results will also be saved to this directory.\n",
+    "- `target_device`: The hardware that the inference models should run on. This defaults to `\"CPU\"`, but any device that is supported by OpenVINO can be used. More details can be found [here](https://docs.openvino.ai/2023.2/openvino_docs_OV_UG_supported_plugins_Supported_Devices.html).\n",
+    "- `frames`: The number of video frames or images to use in the benchmark. These will be selected from the media that we provided in the benchmarking initalization early on in this notebook. Note that all frames/images will be loaded in memory for the benchmarking, so don't make this number too large or you may encounter out of memory issues.\n",
+    "- `repeats`: The number of times the benchmark needs to run on all frames. Increasing this number will give a more accurate estimate of the framerate, but increases the time required for the experiments. The total number of frames that are inferred for each model is `frames * repeats`.\n",
+    "\n",
+    "Run the cell below to execute the benchmark. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15680806-5a03-439a-809b-35e791e509a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = benchmarker.run_throughput_benchmark(\n",
+    "    working_directory=benchmark_folder,\n",
+    "    results_filename=\"results\",\n",
+    "    target_device=\"CPU\",\n",
+    "    frames=100,\n",
+    "    repeats=2,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce06ea12-947c-43df-8844-b867bdf07cf4",
+   "metadata": {},
+   "source": [
+    "## Inspecting the results\n",
+    "The benchmark results are stored in a `results.csv` file in the working directory that we specified earlier. In addition, the `run_throughput_benchmark` method returns the results as a list of dictionaries. This is captured in the `results` variable in the cell above. Using pandas we can easily visualize the results in the notebook.\n",
+    "\n",
+    "Executing the cell below should show a table containing all results from the benchmark experiments. Each row represents one of the deployments for which the benchmark ran. \n",
+    "\n",
+    "The most important columns are ones labelled `model 1 score`, `success` and `fps`. `model 1 score` contains the model accuracy (or F-measure in case of a detection project) for the model used in the deployment. The `success` column indicates if the deployment was able to successfully run inference on all frames. It is either `1` or `0`, with `1` indicating success. Finally, the `fps` column shows the measured average frames per second for the deployment. \n",
+    "\n",
+    "In addition, the table contains some details about the system, indicating the operating system, some info regarding the target device and the python, geti-sdk and openvino versions. This is useful when comparing benchmark results across different hardware setups.\n",
+    "\n",
+    "## Conclusion\n",
+    "Ideally, the table below should help to select which model to pick for deployment in production use. The optimal model has a sufficiently high `model 1 score`, while still reaching the desired `fps`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff3e62e5-0b86-4c7d-a16c-49c2ebe1d969",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "df = pd.DataFrame(results)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad8f1f09-2722-41f5-b338-e83e1cf6c11b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/011_benchmarking_models.ipynb
+++ b/notebooks/011_benchmarking_models.ipynb
@@ -180,6 +180,7 @@
     "At this point all models are trained, optimized and deployed! This means that the benchmark is ready to go. You can run the benchmark by calling the `run_throughput_benchmark` method that the `Benchmarker` provides. It accepts the following arguments:\n",
     "\n",
     "- `working_directory`: The folder in which the deployments are stored that should be benchmarked. Benchmarking results will also be saved to this directory.\n",
+    "- `results_filename`: The name of the file in which the benchmarking results will be saved.\n",
     "- `target_device`: The hardware that the inference models should run on. This defaults to `\"CPU\"`, but any device that is supported by OpenVINO can be used. More details can be found [here](https://docs.openvino.ai/2023.2/openvino_docs_OV_UG_supported_plugins_Supported_Devices.html).\n",
     "- `frames`: The number of video frames or images to use in the benchmark. These will be selected from the media that we provided in the benchmarking initalization early on in this notebook. Note that all frames/images will be loaded in memory for the benchmarking, so don't make this number too large or you may encounter out of memory issues.\n",
     "- `repeats`: The number of times the benchmark needs to run on all frames. Increasing this number will give a more accurate estimate of the framerate, but increases the time required for the experiments. The total number of frames that are inferred for each model is `frames * repeats`.\n",

--- a/requirements/requirements-notebooks.txt
+++ b/requirements/requirements-notebooks.txt
@@ -3,3 +3,4 @@ jupyterlab>=4.0
 jupyter-core>=4.11.2
 ipywidgets>=8.1
 mistune>=2.0.3
+pandas


### PR DESCRIPTION
The `Benchmarker` class is a tool for setting up and managing benchmarks of Geti models on local hardware. At the moment, only benchmarking of the inference rate for the local deployments is supported, but accuracy benchmarking may be added in the future. Currently, the `Benchmarker` allows the user to do the following:

- Specify a project for which models should be benchmarked (can be either single task or task-chain)
- Specify which model architectures should be included 
- Specify which precision levels should be used (i.e. FP16, INT8, ...)
- Specify the media on which the benchmark should run (images from Geti or local images, or a video)

Once this has been specified, the `Benchmarker` will prepare the project. This means it will check whether all required models and optimized models are available, and request training or optimization of the missing models if not. It will also prepare the required deployments to be able to run the inference locally.

Once prepared, the benchmark can run on any target device (i.e. "CPU" or "GPU"), average inference rates for all deployments will be measured and a results file will be saved to disk.

The notebook `011_benchmarking_models` is a tutorial that shows how to initialize, prepare and run the benchmark. 