### PR TITLE
Pin otx to v1.4.3

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,7 +10,7 @@ Pillow==10.1.*
 pathvalidate>=2.5.0
 simplejson==3.19.*
 ipython==8.12.*
-otx==1.4.*
+otx==1.4.3
 openvino==2023.0.*
 openvino-model-api==0.1.5
 certifi>=2022.12.7


### PR DESCRIPTION
OTX v1.4.3 is required for backwards compatibility with models trained in Geti v1.8