### PR TITLE
Minor bug fixes related to deployment

### DIFF
--- a/geti_sdk/deployment/deployment.py
+++ b/geti_sdk/deployment/deployment.py
@@ -127,6 +127,8 @@ class Deployment:
         :return: Deployment instance corresponding to the deployment data in the folder
         """
         deployment_folder = path_to_folder
+        if not isinstance(path_to_folder, str):
+            path_to_folder = str(path_to_folder)
         if not path_to_folder.endswith("deployment"):
             if "deployment" in os.listdir(path_to_folder):
                 deployment_folder = os.path.join(path_to_folder, "deployment")

--- a/geti_sdk/rest_clients/deployment_client.py
+++ b/geti_sdk/rest_clients/deployment_client.py
@@ -388,8 +388,10 @@ class DeploymentClient:
 
         # Wait for the deployment to become available
         stop_polling = False
+        t_start = time.time()
+        timeout = 600
         logging.info("Waiting for the deployment to be created...")
-        while not stop_polling:
+        while not stop_polling and time.time() - t_start < timeout:
             time.sleep(1)
             code_deployment = self._get_deployment_status(code_deployment.id)
             if code_deployment.state == DeploymentState.DONE:
@@ -399,6 +401,15 @@ class DeploymentClient:
                     f"The Intel® Geti™ server failed to create deployment for "
                     f"project '{self.project.name}'."
                 )
+
+        if code_deployment.state != DeploymentState.DONE:
+            raise ValueError(
+                f"The Intel® Geti™ server failed to create deployment for "
+                f"project '{self.project.name}' within 10 minutes. Deployment "
+                f"creation timed out, the current state of the deployment is"
+                f" `{code_deployment.state}` with a progress of "
+                f"{code_deployment.progress:.1f}%"
+            )
 
         # Fetch the deployment package
         deployment = self._fetch_deployment(deployment_id=code_deployment.id)


### PR DESCRIPTION
This PR fixes two bugs:

1. Add a timeout to deployment creation, so that it no longer stalls infinitely if the progress on the Geti server fails silently or gets stuck somehow.
2. Handle Path objects in the `Deployment.from_folder` method