### PR TITLE
Fix issue with undefined label color for prediction

### DIFF
--- a/geti_sdk/data_models/annotation_scene.py
+++ b/geti_sdk/data_models/annotation_scene.py
@@ -13,6 +13,7 @@
 # and limitations under the License.
 
 import copy
+import logging
 from pprint import pformat
 from typing import Any, ClassVar, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -390,3 +391,23 @@ class AnnotationScene:
             media_identifier=self.media_identifier,
             modified=self.modified,
         )
+
+    def resolve_label_names_and_colors(self, labels: List[Label]) -> None:
+        """
+        Add label names and colors to all annotations, based on a list of available
+        labels.
+
+        :param labels: List of labels for the project, serving as a reference point
+            for label names and colors
+        """
+        name_map = {label.id: label.name for label in labels}
+        color_map = {label.id: label.color for label in labels}
+        for annotation in self.annotations:
+            for label in annotation.labels:
+                label.name = name_map.get(label.id, None)
+                label.color = color_map.get(label.id, None)
+                if label.name is None:
+                    logging.warning(
+                        f"Unable to resolve label details for label with id "
+                        f"`{label.id}`"
+                    )

--- a/geti_sdk/data_models/predictions.py
+++ b/geti_sdk/data_models/predictions.py
@@ -134,21 +134,6 @@ class Prediction(AnnotationScene):
     )
     created: Optional[str] = attr.field(converter=str_to_datetime, default=None)
 
-    def resolve_label_names_and_colors(self, labels: List[Label]) -> None:
-        """
-        Add label names and colors to all predictions, based on a list of available
-        labels.
-
-        :param labels: List of labels for the project, serving as a reference point
-            for label names and colors
-        """
-        name_map = {label.id: label.name for label in labels}
-        color_map = {label.id: label.color for label in labels}
-        for annotation in self.annotations:
-            for label in annotation.labels:
-                label.name = name_map[label.id]
-                label.color = color_map[label.id]
-
     def resolve_labels_for_result_media(self, labels: List[Label]) -> None:
         """
         Resolve the label names for all result media available with this Prediction.

--- a/geti_sdk/rest_clients/prediction_client.py
+++ b/geti_sdk/rest_clients/prediction_client.py
@@ -723,4 +723,5 @@ class PredictionClient:
             contenttype=contenttype,
             data=data,
         )
-        return PredictionRESTConverter.from_dict(response)
+        prediction = PredictionRESTConverter.from_dict(response)
+        prediction.resolve_label_names_and_colors(labels=self._labels)

--- a/geti_sdk/rest_clients/prediction_client.py
+++ b/geti_sdk/rest_clients/prediction_client.py
@@ -725,3 +725,4 @@ class PredictionClient:
         )
         prediction = PredictionRESTConverter.from_dict(response)
         prediction.resolve_label_names_and_colors(labels=self._labels)
+        return prediction


### PR DESCRIPTION
This PR fixes an issue with the label color for predictions generated by the `PredictionClient.predict_image` method. Colors and names for the predicted labels should now be set correctly.