### PR TITLE
Update compatibility table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ operating system, as indicated in the table below.
 |:------------|:-------------:|:------------------:|:------------------:|:------------------:|:-----------:|
 | **Linux**   | :x:           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:         |
 | **Windows** | :x:           | :heavy_check_mark: | :heavy_check_mark: | :x:                | :x:         |
-| **MacOS**   | :x:           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:         |
+| **MacOS**   | :x:           | :heavy_check_mark: | :heavy_check_mark: | :x:                | :x:         |
 
 Once you have created and activated a new environment, follow the steps below to install
 the package.


### PR DESCRIPTION
Unfortunately the geti-sdk is not yet compatible with python v3.10 on macOS. The compatibility table in the README.md was updated to reflect this.