### PR TITLE
Fix organization retrieval URL with PAT

### DIFF
--- a/geti_sdk/http_session/geti_session.py
+++ b/geti_sdk/http_session/geti_session.py
@@ -633,7 +633,7 @@ class GetiSession(requests.Session):
                 )
             else:
                 result = self.get_rest_response(
-                    url=f"personal_access_tokens/organization/{self.config.token}",
+                    url="personal_access_tokens/organization",
                     method="GET",
                     include_organization_id=False,
                 )


### PR DESCRIPTION
There has been an update to the endpoint to retrieve the organization ID for a given personal access token. This PR accounts for that.