### PR TITLE
Update job datamodel

### DIFF
--- a/geti_sdk/data_models/job.py
+++ b/geti_sdk/data_models/job.py
@@ -28,7 +28,7 @@ from geti_sdk.data_models.utils import (
     str_to_optional_enum_converter,
 )
 from geti_sdk.http_session import GetiRequestException, GetiSession
-from geti_sdk.platform_versions import GETI_18_VERSION, GetiVersion
+from geti_sdk.platform_versions import GETI_18_VERSION, GETI_116_VERSION, GetiVersion
 
 
 @attr.define(slots=False)
@@ -189,20 +189,20 @@ class Job:
     Representation of a job running on the GETi cluster.
 
     :var name: Name of the job
-    :var description: Description of the job
+    :var description: Description of the job [deprecated in Geti v1.16]
     :var id: Unique database ID of the job
     :var project_id: Unique database ID of the project from which the job originates
-    :var status: JobStatus object holding the current status of the job
+    :var status: JobStatus object holding the current status of the job [deprecated in Geti v1.16]
     :var type: Type of the job
     :var metadata: JobMetadata object holding metadata for the job
     """
 
     name: str
-    description: str
     id: str
-    status: JobStatus
     type: str = attr.field(converter=str_to_enum_converter(JobType))
     metadata: JobMetadata
+    description: Optional[str] = None  # deprecated in Geti v1.16
+    status: Optional[JobStatus] = None  # deprecated in Geti v1.16
     project_id: Optional[str] = None
     creation_time: Optional[str] = attr.field(converter=str_to_datetime, default=None)
     start_time: Optional[str] = attr.field(
@@ -285,10 +285,19 @@ class Job:
             else:
                 raise job_error
 
-        updated_status = JobStatus.from_dict(response["status"])
-        self.status = updated_status
-        self.state = updated_status.state
         self.steps = response.get("steps", None)
+        if session.version < GETI_116_VERSION:
+            updated_status = JobStatus.from_dict(response["status"])
+            self.status = updated_status
+            self.state = updated_status.state
+        else:
+            self.state = JobState(response["state"])
+            self.status = JobStatus(
+                progress=self.current_step / self.total_steps,
+                message=self.current_step_message,
+                state=self.state,
+            )
+
         if self._geti_version is None:
             self.geti_version = session.version
         return self
@@ -305,13 +314,13 @@ class Job:
             session.get_rest_response(
                 url=self.relative_url, method="DELETE", allow_text_response=True
             )
-            self.status.state = JobState.CANCELLED
+            self.state = JobState.CANCELLED
         except GetiRequestException as error:
             if error.status_code == 404:
                 logging.info(
                     f"Job '{self.name}' is not active anymore, unable to delete."
                 )
-                self.status.state = JobState.INACTIVE
+                self.state = JobState.INACTIVE
             else:
                 raise error
         return self
@@ -338,14 +347,14 @@ class Job:
         """
         Return True if the job finished successfully, False otherwise
         """
-        return self.status.state == JobState.FINISHED
+        return self.state == JobState.FINISHED
 
     @property
     def is_running(self) -> bool:
         """
         Return True if the job is currently running, False otherwise
         """
-        return self.status.state == JobState.RUNNING
+        return self.state == JobState.RUNNING
 
     def _get_step_information(self) -> Tuple[int, int]:
         """
@@ -402,11 +411,26 @@ class Job:
         else:
             current_step_index = self.current_step - 1
             if current_step_index < 0 or current_step_index >= len(self.steps):
-                if self.status.state != JobState.SCHEDULED:
+                if self.state != JobState.SCHEDULED:
                     return ""
                 else:
                     return "Awaiting job execution"
             return self.steps[current_step_index].get("step_name", "")
+
+    @property
+    def current_step_progress(self) -> float:
+        """
+        Return the progress of the current step for the job
+
+        :return: float indicating the progress of the current step in the job
+        """
+        if self.geti_version <= GETI_18_VERSION:
+            return self.status.progress
+        else:
+            current_step_index = self.current_step - 1
+            if current_step_index < 0 or current_step_index >= len(self.steps):
+                return 0.0
+            return self.steps[current_step_index].get("progress", 0.0)
 
     @property
     def geti_version(self) -> GetiVersion:

--- a/geti_sdk/data_models/status.py
+++ b/geti_sdk/data_models/status.py
@@ -32,7 +32,7 @@ class StatusSummary:
     """
 
     progress: float
-    time_remaining: float
+    time_remaining: Optional[float] = None  # Deprecated in Geti v1.16
     message: Optional[str] = None
 
     def __attrs_post_init__(self):

--- a/geti_sdk/demos/demo_projects/utils.py
+++ b/geti_sdk/demos/demo_projects/utils.py
@@ -51,7 +51,7 @@ def ensure_project_is_trained(geti: Geti, project: Project) -> bool:
     )
     # If there are no jobs running for the project, we launch them
     jobs = training_client.get_jobs(project_only=True)
-    running_jobs = [job for job in jobs if job.status.state == JobState.RUNNING]
+    running_jobs = [job for job in jobs if job.state == JobState.RUNNING]
     tasks = project.get_trainable_tasks()
 
     new_jobs = []

--- a/geti_sdk/rest_clients/model_client.py
+++ b/geti_sdk/rest_clients/model_client.py
@@ -518,7 +518,7 @@ class ModelClient:
                 f"Cannot get model for job `{job.description}`. This job does not "
                 f"belong to the project managed by this ModelClient instance."
             )
-        if job.status.state != JobState.FINISHED:
+        if job.state != JobState.FINISHED:
             raise ValueError(
                 f"Job `{job.description}` is not finished yet, unable to retrieve "
                 f"model for the job. Please wait until job is finished"

--- a/geti_sdk/rest_clients/training_client.py
+++ b/geti_sdk/rest_clients/training_client.py
@@ -358,7 +358,7 @@ class TrainingClient:
                 if job.metadata.task is not None:
                     if job.metadata.task.task_id == task.id:
                         if running_only:
-                            if job.status.state == JobState.RUNNING:
+                            if job.state == JobState.RUNNING:
                                 task_jobs.append(job)
                         else:
                             task_jobs.append(job)

--- a/tests/nightly/test_nightly_project.py
+++ b/tests/nightly/test_nightly_project.py
@@ -94,7 +94,7 @@ class TestNightlyProject:
 
         jobs = training_client.monitor_jobs(jobs=jobs, timeout=10000)
         for job in jobs:
-            assert job.status.state == JobState.FINISHED
+            assert job.state == JobState.FINISHED
 
     def test_upload_and_predict_image(
         self,

--- a/tests/pre-merge/integration/rest_clients/test_model_and_prediction_client.py
+++ b/tests/pre-merge/integration/rest_clients/test_model_and_prediction_client.py
@@ -88,7 +88,7 @@ class TestModelAndPredictionClient:
 
         # Test that getting model for the train job works
         if fxt_test_mode == SdkTestMode.OFFLINE:
-            job.status.state = JobState.FINISHED
+            job.state = JobState.FINISHED
         model = fxt_project_service.model_client.get_model_for_job(
             job=job, check_status=False
         )

--- a/tests/pre-merge/integration/rest_clients/test_training_client.py
+++ b/tests/pre-merge/integration/rest_clients/test_training_client.py
@@ -70,16 +70,15 @@ class TestTrainingClient:
 
         # Update job status
         job.update(fxt_project_service.session)
-        job_state = job.status.state
-        if job_state in JobState.active_states():
+        if job.state in JobState.active_states():
             # Cancel the job
             logging.info(f"Job '{job.name}' is still active, cancelling...")
             job.cancel(fxt_project_service.session)
         else:
             logging.info(
-                f"Job '{job.name}' has already excited with status {job_state}."
+                f"Job '{job.name}' has already excited with status {job.state}."
             )
-        logging.info(job_state)
+        logging.info(job.state)
 
     @pytest.mark.vcr()
     def test_get_status(


### PR DESCRIPTION
This PR makes `Job.description` and `Job.status` optional, to account for changes in the REST contract for jobs in Geti v1.16