### PR TITLE
Further restrict workflow permissions

### DIFF
--- a/.github/workflows/pre-merge-tests.yml
+++ b/.github/workflows/pre-merge-tests.yml
@@ -16,8 +16,8 @@ env:
 
 permissions:
   contents: read
-  checks: write
-  actions: write
+  checks: read
+  actions: read
 
 jobs:
   pr_tests:

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -18,9 +18,7 @@ jobs:
   security:
     runs-on: [self-hosted, sdk-runner]
     permissions:
-      # required for all workflows
-      security-events: write
-      # only required for workflows in private repositories
+      security-events: read
       actions: read
       contents: read
     steps:


### PR DESCRIPTION
To ensure compliance with OpenSSF requirements, this PR further restricts the permissions for the github actions workflows. They should still have sufficient permissions to function normally.