### PR TITLE
End support for Platforms versions lower than 1.15

### DIFF
--- a/geti_sdk/data_models/algorithms.py
+++ b/geti_sdk/data_models/algorithms.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, Optional
 
 import attr
 
-from geti_sdk.data_models.enums import Domain, TaskType
+from geti_sdk.data_models.enums import TaskType
 from geti_sdk.data_models.utils import str_to_optional_enum_converter
 
 from .utils import attr_value_serializer, remove_null_fields
@@ -32,38 +32,15 @@ class Algorithm:
     model_size: str
     model_template_id: str
     gigaflops: float
-    algorithm_name: Optional[str] = None  # Deprecated in Geti v1.16, use 'name' instead
     name: Optional[str] = None
     summary: Optional[str] = None
-    domain: Optional[str] = attr.field(
-        default=None, converter=str_to_optional_enum_converter(Domain)
-    )
-    # `domain` is deprecated in SC1.1, replaced by task_type
     task_type: Optional[str] = attr.field(
         default=None, converter=str_to_optional_enum_converter(TaskType)
     )
     supports_auto_hpo: Optional[bool] = None
-    recommended_choice: Optional[bool] = (
-        None  # Deprecated in Geti v1.16, use 'default_algorithm' instead
-    )
     default_algorithm: Optional[bool] = None  # Added in Geti v1.16
     performance_category: Optional[str] = None  # Added in Geti v1.9
     lifecycle_stage: Optional[str] = None  # Added in Geti v1.9
-
-    def __attrs_post_init__(self):
-        """
-        Convert domain to task type for backward compatibility with earlier versions of
-        the Intel® Geti™ platform
-        """
-        if self.default_algorithm is None:
-            # For older Geti versions, that were still using 'recommended choice'
-            self.default_algorithm = self.recommended_choice
-        if self.name is None:
-            # For older Geti versions, that were still using 'algorithm_name'
-            self.name = self.algorithm_name
-        if self.domain is not None and self.task_type is None:
-            self.task_type = TaskType.from_domain(self.domain)
-            self.domain = None
 
     def to_dict(self) -> Dict[str, Any]:
         """

--- a/geti_sdk/data_models/label.py
+++ b/geti_sdk/data_models/label.py
@@ -33,9 +33,6 @@ class LabelSource:
     user_id: Optional[str] = None
     model_id: Optional[str] = None
     model_storage_id: Optional[str] = None
-    # keys 'id' and 'type' are deprecated in v1.2, but required for v1.1
-    id: Optional[str] = None
-    type: Optional[str] = None
 
 
 @attr.define

--- a/geti_sdk/data_models/media.py
+++ b/geti_sdk/data_models/media.py
@@ -116,8 +116,6 @@ class MediaItem:
     type: str = attr.field(converter=str_to_media_type)
     upload_time: str = attr.field(converter=str_to_datetime)
     media_information: MediaInformation
-    state: Optional[str] = None
-    # State is deprecated in SC1.1, replaced by `annotation_state_per_task`
     annotation_state_per_task: Optional[List[TaskAnnotationState]] = None
     thumbnail: Optional[str] = None
     uploader_id: Optional[str] = None

--- a/geti_sdk/data_models/media.py
+++ b/geti_sdk/data_models/media.py
@@ -102,10 +102,10 @@ class MediaItem:
 
     :var id: Unique database ID of the media entity
     :var name: Filename of the media entity
-    :var state: Annotation state of the media entity
     :var type: MediaType of the entity
     :var upload_time: Time and date at which the entity was uploaded to the system
     :var thumbnail: URL that can be used to get a thumbnail for the media entity
+    :var annotation_state_per_task: Annotation state of the media entity
     :var media_information: Container holding basic information such as width and
         height about the media entity
     :param last_annotator_id: the name or id of the editor.
@@ -444,7 +444,7 @@ class VideoFrame(MediaItem):
             upload_time=video.upload_time,
             thumbnail=f"{base_url}/display/thumb",
             media_information=frame_information,
-            state=video.state,
+            annotation_state_per_task=video.annotation_state_per_task,
             id=video.id,
             video_name=video.name,
         )

--- a/geti_sdk/data_models/model.py
+++ b/geti_sdk/data_models/model.py
@@ -41,7 +41,6 @@ class OptimizationCapabilities:
     """
 
     is_nncf_supported: bool
-    is_filter_pruning_enabled: Optional[bool] = None  # deprecated in v1.1
     is_filter_pruning_supported: Optional[bool] = None
 
 
@@ -223,7 +222,7 @@ class Model(BaseModel):
     optimized_models: List[OptimizedModel] = attr.field(kw_only=True)
     labels: Optional[List[Label]] = None
     version: Optional[int] = attr.field(default=None, kw_only=True)
-    # 'version' is deprecated in v1.1
+    # 'version' is deprecated in v1.1 -- IS IT?
     training_dataset_info: Optional[Dict[str, str]] = None
 
     @property

--- a/geti_sdk/data_models/model.py
+++ b/geti_sdk/data_models/model.py
@@ -42,6 +42,7 @@ class OptimizationCapabilities:
 
     is_nncf_supported: bool
     is_filter_pruning_supported: Optional[bool] = None
+    is_filter_pruning_enabled: Optional[bool] = None
 
 
 @attr.define

--- a/geti_sdk/data_models/performance.py
+++ b/geti_sdk/data_models/performance.py
@@ -35,8 +35,6 @@ class TaskPerformance:
     """
     Task Performance metrics in Intel® Geti™.
 
-    :var task_node_id: Unique ID of the task to which this Performance metric
-        applies. Deprecated in Geti v1.16, use `task_id` instead.
     :var task_id: Unique ID of the task to which this Performance metric
         applies.
     :var score: Score of the project or model for each task
@@ -46,18 +44,10 @@ class TaskPerformance:
         classification of the full image for each task
     """
 
-    task_node_id: Optional[str] = None  # Deprecated in Geti v1.16
     task_id: Optional[str] = None
     score: Optional[Score] = None
     local_score: Optional[Score] = None
     global_score: Optional[Score] = None
-
-    def __attrs_post_init__(self):
-        """
-        Post initialization hook
-        """
-        if self.task_id is None:
-            self.task_id = self.task_node_id
 
 
 @attr.define()

--- a/geti_sdk/data_models/status.py
+++ b/geti_sdk/data_models/status.py
@@ -26,13 +26,10 @@ class StatusSummary:
     NOTE: the 'message' attribute was removed in Geti 1.1
 
     :var progress: Training progress, if a model is being trained
-    :var time_remaining: Estimated time remaining on the training process, if a model
-        is being trained.
     :var message: Optional Human readable message describing the status
     """
 
     progress: float
-    time_remaining: Optional[float] = None  # Deprecated in Geti v1.16
     message: Optional[str] = None
 
     def __attrs_post_init__(self):
@@ -146,7 +143,6 @@ class ProjectStatus:
         tasks in the project
     :var n_required_annotations: Total number of required annotations for the project,
         before auto-training can be started
-    :var project_score: Accuracy score for the project
     :var status: StatusSummary object that contains (among others) a human readable
         message describing the status of the project
     :var tasks: List of TaskStatus objects, detailing the status of each task in the
@@ -160,7 +156,6 @@ class ProjectStatus:
     tasks: List[TaskStatus]
     n_new_annotations: Optional[int] = None  # Added in Geti v1.1
     project_performance: Optional[Performance] = None
-    project_score: Optional[float] = None  # Deprecated in Geti 1.0, to be removed
     n_running_jobs: Optional[int] = None
     n_running_jobs_project: Optional[int] = None
 

--- a/geti_sdk/deployment/deployed_model.py
+++ b/geti_sdk/deployment/deployed_model.py
@@ -26,6 +26,7 @@ import numpy as np
 from openvino.model_api.adapters import OpenvinoAdapter, OVMSAdapter
 from openvino.model_api.models import Model as model_api_Model
 from openvino.runtime import Core
+from packaging.version import Version
 
 from geti_sdk.data_models import OptimizedModel, Project, TaskConfiguration
 from geti_sdk.data_models.enums.domain import Domain
@@ -162,6 +163,7 @@ class DeployedModel(OptimizedModel):
                     )
 
                 self._model_python_path = os.path.join(source, PYTHON_DIR_NAME)
+
             # A model is being loaded from disk, check if it is a legacy model
             # We support OTX models starting from version 1.5.0
             otx_version = get_package_version_from_requirements(
@@ -171,11 +173,12 @@ class DeployedModel(OptimizedModel):
                 package_name="otx",
             )
             if otx_version:  # Empty string if package not found
-                otx_version = otx_version.split(".")
-                if int(otx_version[0]) <= 1 and int(otx_version[1]) < 5:
+                if Version(otx_version) < Version("1.5.0"):
                     raise ValueError(
-                        "Model version is not supported. Please use a model trained with "
-                        "OTX version 1.5.0 or higher."
+                        "\n"
+                        "This deployment model is not compatible with the current SDK. Proposed solutions:\n"
+                        "1. Please deploy a model using GETi Platform version 2.0.0 or higher.\n"
+                        "2. Downgrade to a compatible GETi-SDK version to continue using this model.\n\n"
                     )
 
         elif isinstance(source, GetiSession):

--- a/geti_sdk/http_session/geti_session.py
+++ b/geti_sdk/http_session/geti_session.py
@@ -102,7 +102,7 @@ class GetiSession(requests.Session):
         if self.version < GETI_116_VERSION:
             raise ValueError(
                 "The Intel® Geti™ server version is not supported by this SDK. Please "
-                "update the Intel® Geti™ server to version 2.0 or later."
+                "update the Intel® Geti™ server to version 2.0 or later, or us the previous version of the SDK."
             )
 
     @property

--- a/geti_sdk/http_session/geti_session.py
+++ b/geti_sdk/http_session/geti_session.py
@@ -68,7 +68,7 @@ class GetiSession(requests.Session):
         if server_config.proxies is None:
             self._proxies: Dict[str, str] = {}
         else:
-            self._proxies = {"proxies": server_config.proxies}
+            self._proxies = server_config.proxies
 
         # Configure certificate verification
         if not server_config.has_valid_certificate:
@@ -149,7 +149,7 @@ class GetiSession(requests.Session):
             "&scope=openid+profile+groups+email+offline_access"
         )
         url = f"{self.config.host}/dex/auth/regular_users?{params}"
-        response = self.get(url, allow_redirects=False, **self._proxies)
+        response = self.get(url, allow_redirects=False, proxies=self._proxies)
         login_page_url = self._follow_login_redirects(response)
         return login_page_url
 
@@ -194,7 +194,7 @@ class GetiSession(requests.Session):
             cookies=cookies,
             headers=headers,
             allow_redirects=True,
-            **self._proxies,
+            proxies=self._proxies,
         )
         self._handle_dex_response(response)
         if verbose:
@@ -275,7 +275,7 @@ class GetiSession(requests.Session):
             self.headers.pop("x-geti-csrf-protection", "")
 
         try:
-            response = self.request(**request_params, **self._proxies)
+            response = self.request(**request_params, proxies=self._proxies)
         except requests.exceptions.SSLError as error:
             raise requests.exceptions.SSLError(
                 f"Connection to Intel® Geti™ server at '{self.config.host}' failed, "
@@ -333,7 +333,9 @@ class GetiSession(requests.Session):
                 + "/oauth2/sign_out"
             )
             try:
-                response = self.request(url=sign_out_url, method="GET", **self._proxies)
+                response = self.request(
+                    url=sign_out_url, method="GET", proxies=self._proxies
+                )
 
                 if response.status_code in SUCCESS_STATUS_CODES:
                     if verbose:
@@ -469,7 +471,7 @@ class GetiSession(requests.Session):
                 for file_name, file_buffer in request_params["files"].items():
                     file_buffer.seek(0, 0)
 
-            response = self.request(**request_params, **self._proxies)
+            response = self.request(**request_params, proxies=self._proxies)
 
             if response.status_code in SUCCESS_STATUS_CODES:
                 return response
@@ -598,7 +600,7 @@ class GetiSession(requests.Session):
             url=f"{self.config.host}/dex/token",
             data=data,
             allow_redirects=True,
-            **self._proxies,
+            proxies=self._proxies,
         )
         token = login_response.json().get("access_token", None)
         self._cookies.update({GETI_COOKIE_NAME: token})

--- a/geti_sdk/http_session/geti_session.py
+++ b/geti_sdk/http_session/geti_session.py
@@ -98,7 +98,7 @@ class GetiSession(requests.Session):
                     "Authentication via username and password is deprecated and will be "
                     "removed in a future version of the SDK. Please use a personal access token."
                 )
-            self.authenticate(verbose=True)
+            self.authenticate_with_password(verbose=True)
             self.use_token = False
         else:  # ServerTokenConfig
             self.use_token = True
@@ -180,7 +180,7 @@ class GetiSession(requests.Session):
             login_page_url = response.url
         return login_page_url
 
-    def authenticate(self, verbose: bool = True):
+    def authenticate_with_password(self, verbose: bool = True):
         """
         Get a new authentication cookie from the server.
 
@@ -463,7 +463,7 @@ class GetiSession(requests.Session):
             logging.info("Authentication may have expired, re-authenticating...")
             self.logged_in = False
             if not self.use_token:
-                self.authenticate(verbose=False)
+                self.authenticate_with_password(verbose=False)
                 logging.info("Authentication complete.")
 
             else:

--- a/geti_sdk/rest_clients/annotation_clients/base_annotation_client.py
+++ b/geti_sdk/rest_clients/annotation_clients/base_annotation_client.py
@@ -35,7 +35,6 @@ from geti_sdk.data_models.containers.media_list import MediaList
 from geti_sdk.data_models.media import MediaInformation, MediaItem
 from geti_sdk.data_models.project import Dataset
 from geti_sdk.http_session import GetiRequestException, GetiSession
-from geti_sdk.platform_versions import GETI_116_VERSION
 from geti_sdk.rest_clients.dataset_client import DatasetClient
 from geti_sdk.rest_converters import AnnotationRESTConverter
 from geti_sdk.rest_converters.annotation_rest_converter import (
@@ -109,31 +108,22 @@ class BaseAnnotationClient:
         else:
             raise ValueError(f"Invalid media type specified: {media_type}.")
 
-        if self.session.version < GETI_116_VERSION:
-            get_media_url = (
-                f"workspaces/{self.workspace_id}/projects/{self._project.id}"
-                f"/datasets/{dataset.id}/media/"
-                f"{media_name}?top=500"
-            )
-            response = self.session.get_rest_response(url=get_media_url, method="GET")
-            total_number_of_media: int = response["media_count"][media_name]
-        else:
-            url = (
-                f"workspaces/{self.workspace_id}/projects/{self._project.id}"
-                f"/datasets/{dataset.id}/media:query?top=500"
-            )
-            data = {
-                "condition": "and",
-                "rules": [
-                    {
-                        "field": "MEDIA_TYPE",
-                        "operator": "EQUAL",
-                        "value": single_media_name,
-                    }
-                ],
-            }
-            response = self.session.get_rest_response(url=url, method="POST", data=data)
-            total_number_of_media: int = response[f"total_matched_{media_name}"]
+        url = (
+            f"workspaces/{self.workspace_id}/projects/{self._project.id}"
+            f"/datasets/{dataset.id}/media:query?top=500"
+        )
+        data = {
+            "condition": "and",
+            "rules": [
+                {
+                    "field": "MEDIA_TYPE",
+                    "operator": "EQUAL",
+                    "value": single_media_name,
+                }
+            ],
+        }
+        response = self.session.get_rest_response(url=url, method="POST", data=data)
+        total_number_of_media: int = response[f"total_matched_{media_name}"]
 
         raw_media_list: List[Dict[str, Any]] = []
         while len(raw_media_list) < total_number_of_media:

--- a/geti_sdk/rest_clients/dataset_client.py
+++ b/geti_sdk/rest_clients/dataset_client.py
@@ -16,7 +16,6 @@ from typing import List, Optional
 
 from geti_sdk.data_models import Dataset, Project
 from geti_sdk.http_session import GetiSession
-from geti_sdk.platform_versions import GETI_116_VERSION
 from geti_sdk.utils import deserialize_dictionary
 
 
@@ -39,8 +38,6 @@ class DatasetClient:
         :return: The created dataset
         """
         request_data = {"name": name}
-        if self.session.version < GETI_116_VERSION:
-            request_data.update({"use_for_training": False})
         response = self.session.get_rest_response(
             url=self.base_url,
             method="POST",

--- a/geti_sdk/rest_clients/media_client/media_client.py
+++ b/geti_sdk/rest_clients/media_client/media_client.py
@@ -40,7 +40,6 @@ from geti_sdk.data_models.enums.media_type import (
 from geti_sdk.data_models.project import Dataset
 from geti_sdk.data_models.utils import numpy_from_buffer
 from geti_sdk.http_session import GetiRequestException, GetiSession
-from geti_sdk.platform_versions import GETI_116_VERSION
 from geti_sdk.rest_clients.dataset_client import DatasetClient
 from geti_sdk.rest_converters.media_rest_converter import MediaRESTConverter
 
@@ -111,27 +110,19 @@ class BaseMediaClient(Generic[MediaTypeVar]):
         if dataset is None:
             dataset = self._project.training_dataset
 
-        if self.session.version < GETI_116_VERSION:
-            response = self.session.get_rest_response(
-                url=f"{self.base_url(dataset=dataset)}?top=500", method="GET"
-            )
-            total_number_of_media: int = response["media_count"][self.plural_media_name]
-        else:
-            url = f"{self._base_url}/{dataset.id}/media:query?top=500"
-            data = {
-                "condition": "and",
-                "rules": [
-                    {
-                        "field": "MEDIA_TYPE",
-                        "operator": "EQUAL",
-                        "value": f"{self._MEDIA_TYPE}",
-                    }
-                ],
-            }
-            response = self.session.get_rest_response(url=url, method="POST", data=data)
-            total_number_of_media: int = response[
-                f"total_matched_{self.plural_media_name}"
-            ]
+        url = f"{self._base_url}/{dataset.id}/media:query?top=500"
+        data = {
+            "condition": "and",
+            "rules": [
+                {
+                    "field": "MEDIA_TYPE",
+                    "operator": "EQUAL",
+                    "value": f"{self._MEDIA_TYPE}",
+                }
+            ],
+        }
+        response = self.session.get_rest_response(url=url, method="POST", data=data)
+        total_number_of_media: int = response[f"total_matched_{self.plural_media_name}"]
 
         raw_media_list: List[Dict[str, Any]] = []
         while len(raw_media_list) < total_number_of_media:

--- a/geti_sdk/rest_clients/model_client.py
+++ b/geti_sdk/rest_clients/model_client.py
@@ -29,7 +29,6 @@ from geti_sdk.data_models import (
 )
 from geti_sdk.data_models.enums import JobState, JobType, OptimizationType
 from geti_sdk.http_session import GetiSession
-from geti_sdk.platform_versions import GETI_116_VERSION
 from geti_sdk.rest_converters import ModelRESTConverter
 from geti_sdk.utils import get_supported_algorithms
 from geti_sdk.utils.job_helpers import get_job_with_timeout, monitor_job
@@ -640,12 +639,8 @@ class ModelClient:
         response = self.session.get_rest_response(
             url=optimize_model_url, method="POST", data=payload
         )
-        if self.session.version < GETI_116_VERSION:
-            job_id = response["job_ids"][0]
-        else:
-            job_id = response["job_id"]
         job = get_job_with_timeout(
-            job_id=job_id,
+            job_id=response["job_id"],
             session=self.session,
             workspace_id=self.workspace_id,
             job_type="optimization",

--- a/geti_sdk/utils/algorithm_helpers.py
+++ b/geti_sdk/utils/algorithm_helpers.py
@@ -48,12 +48,13 @@ def get_supported_algorithms(
 
     algorithm_rest_response = rest_session.get_rest_response(url=url, method="GET")
 
-    filtered_response = [
-        algo
-        for algo in algorithm_rest_response["supported_algorithms"]
-        if algo["task_type"].upper() == task_type.name
-    ]
-    algorithm_rest_response["items"] = filtered_response
+    if task_type:
+        filtered_response = [
+            algo
+            for algo in algorithm_rest_response["supported_algorithms"]
+            if algo["task_type"].upper() == task_type.name
+        ]
+        algorithm_rest_response["items"] = filtered_response
     return AlgorithmList.from_rest(algorithm_rest_response)
 
 

--- a/geti_sdk/utils/algorithm_helpers.py
+++ b/geti_sdk/utils/algorithm_helpers.py
@@ -18,7 +18,6 @@ from geti_sdk.data_models.containers import AlgorithmList
 from geti_sdk.data_models.enums import Domain, TaskType
 from geti_sdk.data_models.project import Project
 from geti_sdk.http_session import GetiSession
-from geti_sdk.platform_versions import GETI_18_VERSION
 
 
 def get_supported_algorithms(
@@ -48,24 +47,17 @@ def get_supported_algorithms(
     if task_type is not None and domain is not None:
         raise ValueError("Please specify either task type or domain, but not both")
     elif task_type is not None:
-        query = f"?task_type={task_type}"
         filter_by_task_type = True
     elif domain is not None:
         task_type = TaskType.from_domain(domain)
-        query = f"?task_type={task_type}"
         filter_by_task_type = True
-    else:
-        query = ""
 
-    if rest_session.version <= GETI_18_VERSION:
-        url = f"supported_algorithms{query}"
-    else:
-        if (workspace_id is None) or (project is None):
-            raise ValueError(
-                "For Geti v1.9 or higher, passing `workspace_id` and `project` is "
-                "mandatory in order to retrieve the supported algorithms"
-            )
-        url = f"workspaces/{workspace_id}/projects/{project.id}/supported_algorithms"
+    if (workspace_id is None) or (project is None):
+        raise ValueError(
+            "For Geti v1.9 or higher, passing `workspace_id` and `project` is "
+            "mandatory in order to retrieve the supported algorithms"
+        )
+    url = f"workspaces/{workspace_id}/projects/{project.id}/supported_algorithms"
 
     algorithm_rest_response = rest_session.get_rest_response(url=url, method="GET")
 
@@ -95,15 +87,12 @@ def get_default_algorithm_info(
     :return: Dictionary mapping the default algorithm name to the TaskType, for each
         task in the project
     """
-    if session.version <= GETI_18_VERSION:
-        url = "supported_algorithms"
-    else:
-        if (workspace_id is None) or (project is None):
-            raise ValueError(
-                "For Geti v1.9 or higher, passing `workspace_id` and `project` is "
-                "mandatory in order to retrieve the supported algorithms"
-            )
-        url = f"workspaces/{workspace_id}/projects/{project.id}/supported_algorithms"
+    if (workspace_id is None) or (project is None):
+        raise ValueError(
+            "For Geti v1.9 or higher, passing `workspace_id` and `project` is "
+            "mandatory in order to retrieve the supported algorithms"
+        )
+    url = f"workspaces/{workspace_id}/projects/{project.id}/supported_algorithms"
 
     algorithm_rest_response = session.get_rest_response(url=url, method="GET")
     defaults = algorithm_rest_response.get("default_algorithms", None)

--- a/tests/fixtures/unit_tests/geti.py
+++ b/tests/fixtures/unit_tests/geti.py
@@ -19,6 +19,7 @@ from pytest_mock import MockerFixture
 
 from geti_sdk import Geti
 from geti_sdk.http_session import GetiSession, ServerCredentialConfig
+from geti_sdk.http_session.geti_session import ONPREM_MODE
 from geti_sdk.http_session.server_config import ServerConfig
 
 
@@ -37,7 +38,13 @@ def fxt_mocked_session_factory(
         return_value: Optional[Union[List, Dict]] = None,
         server_config: Optional[ServerConfig] = None,
     ) -> GetiSession:
-        mocker.patch("geti_sdk.http_session.geti_session.GetiSession.authenticate")
+        mocker.patch(
+            "geti_sdk.http_session.geti_session.GetiSession.platform_serving_mode",
+            ONPREM_MODE,
+        )
+        mocker.patch(
+            "geti_sdk.http_session.geti_session.GetiSession.authenticate_with_password"
+        )
         mocker.patch(
             "geti_sdk.http_session.geti_session.GetiSession.get_rest_response",
             return_value=return_value,

--- a/tests/fixtures/unit_tests/geti.py
+++ b/tests/fixtures/unit_tests/geti.py
@@ -45,10 +45,15 @@ def fxt_mocked_session_factory(
         mocker.patch(
             "geti_sdk.http_session.geti_session.GetiSession._get_product_info_and_set_api_version",
             return_value={
-                "build-version": "1.0.0-release-20221005164936",
-                "product-version": "1.0.0",
+                "product-version": "2.0.0",
+                "build-version": "2.0.0-test-20240417130126",
                 "smtp-defined": "True",
+                "environment": "on-prem",
             },
+        )
+        mocker.patch(
+            "geti_sdk.http_session.geti_session.GetiSession._get_organization_id",
+            return_value="000000000000000000000001",
         )
         if server_config is None:
             server_config = fxt_mocked_server_credential_config

--- a/tests/pre-merge/integration/http_session/test_geti_session.py
+++ b/tests/pre-merge/integration/http_session/test_geti_session.py
@@ -22,7 +22,7 @@ class TestGetiSession:
         """
         Test that the authenticated GetiSession instance contains authentication cookies
         """
-        fxt_geti_session.authenticate(verbose=False)
+        fxt_geti_session.authenticate_with_password(verbose=False)
 
     def test_product_version(self, fxt_geti_session: GetiSession):
         """

--- a/tests/pre-merge/unit/http_session/test_geti_session_unit.py
+++ b/tests/pre-merge/unit/http_session/test_geti_session_unit.py
@@ -1,0 +1,126 @@
+# Copyright (C) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+from typing import Any, Dict
+
+import pytest
+from pytest_mock import MockerFixture
+
+from geti_sdk.http_session.geti_session import (
+    ONPREM_MODE,
+    SAAS_MODE,
+    GetiSession,
+    ServerTokenConfig,
+)
+
+
+class TestPlatformAuthentication:
+    def test_authentication_saas(
+        self,
+        fxt_mocked_server_credential_config,
+        fxt_server_token_config_parameters: Dict[str, Any],
+        mocker: MockerFixture,
+    ):
+        # Arrange
+        mocker.patch(
+            "geti_sdk.http_session.geti_session.GetiSession.platform_serving_mode",
+            SAAS_MODE,
+        )
+        mocker.patch(
+            "geti_sdk.http_session.geti_session.GetiSession._get_product_info_and_set_api_version",
+            return_value={
+                "product-version": "2.0.0",
+                "build-version": "2.0.0-test-20240417130126",
+                "smtp-defined": "True",
+                "environment": "saas",
+            },
+        )
+        mocker.patch(
+            "geti_sdk.http_session.geti_session.GetiSession._get_organization_id",
+            return_value="dummy_org_id",
+        )
+        token_server_config = ServerTokenConfig(**fxt_server_token_config_parameters)
+
+        # Act
+        # Username and password auth fails with SAAS
+        with pytest.raises(ValueError):
+            GetiSession(fxt_mocked_server_credential_config)
+
+        # Token-based auth works with SAAS
+        GetiSession(token_server_config)
+
+    def test_authentication_onprem(
+        self,
+        fxt_mocked_server_credential_config,
+        fxt_server_token_config_parameters: Dict[str, Any],
+        mocker: MockerFixture,
+    ):
+        # Arrange
+        mocker.patch(
+            "geti_sdk.http_session.geti_session.GetiSession.platform_serving_mode",
+            ONPREM_MODE,
+        )
+        mocker.patch(
+            "geti_sdk.http_session.geti_session.GetiSession._get_product_info_and_set_api_version",
+            return_value={
+                "product-version": "2.0.0",
+                "build-version": "2.0.0-test-20240417130126",
+                "smtp-defined": "True",
+                "environment": "on-prem",
+            },
+        )
+        mocker.patch(
+            "geti_sdk.http_session.geti_session.GetiSession._get_organization_id",
+            return_value="dummy_org_id",
+        )
+        mocker.patch(
+            "geti_sdk.http_session.geti_session.GetiSession.authenticate_with_password"
+        )
+
+        # Act
+        # Username and password will soon be deprecated for on-prem
+        with pytest.warns():
+            GetiSession(fxt_mocked_server_credential_config)
+
+    def test_authentication_legacy(
+        self,
+        fxt_mocked_server_credential_config,
+        mocker: MockerFixture,
+    ):
+        # Arrange
+        mocker.patch(
+            "geti_sdk.http_session.geti_session.GetiSession.platform_serving_mode",
+            ONPREM_MODE,
+        )
+        mocker.patch(
+            "geti_sdk.http_session.geti_session.GetiSession._get_product_info_and_set_api_version",
+            return_value={
+                "product-version": "1.8.0",
+                "build-version": "1.8.0-test-20240417130126",
+                "smtp-defined": "True",
+                "environment": "on-prem",
+            },
+        )
+        mocker.patch(
+            "geti_sdk.http_session.geti_session.GetiSession._get_organization_id",
+            return_value="dummy_org_id",
+        )
+        mocker.patch(
+            "geti_sdk.http_session.geti_session.GetiSession.authenticate_with_password"
+        )
+
+        # Act
+        # Legacy platforms are no longer supported
+        with pytest.raises(ValueError):
+            GetiSession(fxt_mocked_server_credential_config)

--- a/tests/pre-merge/unit/test_geti_unit.py
+++ b/tests/pre-merge/unit/test_geti_unit.py
@@ -33,17 +33,8 @@ class TestGeti:
     ):
         # Arrange
         mocker.patch("geti_sdk.geti.GetiSession", new=fxt_mocked_session_factory)
-        mock_acquire_token = mocker.patch(
-            "geti_sdk.http_session.geti_session.GetiSession._acquire_access_token",
-            return_value=DUMMY_TOKEN,
-        )
         mock_get_workspace_id = mocker.patch(
             "geti_sdk.geti.get_default_workspace_id", return_value=1
-        )
-        mock_authentication_service = mocker.patch(
-            "geti_sdk.http_session.geti_session.GetiSession.authentication_service",
-            return_value="dex-old",
-            new_callable=mocker.PropertyMock,
         )
 
         # Act and assert
@@ -64,8 +55,6 @@ class TestGeti:
                 password=DUMMY_PASSWORD,
             )
         assert isinstance(geti.session.config, ServerTokenConfig)
-        mock_acquire_token.assert_called_once()
-        mock_authentication_service.assert_called_once()
         mock_get_workspace_id.assert_called_once()
 
         # Both host and server_config specified, host will be ignored
@@ -80,13 +69,7 @@ class TestGeti:
 
         # When the new authentication mechanism is detected (Geti v1.15 and up), do
         # not acquire token
-        mock_authentication_service = mocker.patch(
-            "geti_sdk.http_session.geti_session.GetiSession.authentication_service",
-            return_value="dex-new",
-            new_callable=mocker.PropertyMock,
-        )
         geti = Geti(host=DUMMY_HOST, token=DUMMY_TOKEN)
-        mock_authentication_service.assert_called_once()
         assert "x-api-key" in geti.session.headers.keys()
 
     def test_logout(self, mocker: MockerFixture, fxt_mocked_geti: Geti):


### PR DESCRIPTION
- [x] Remove logic branching allowing to interact with Platforms older than 1.15
- [x] Add unit tests

This PR drops support for older GETi Platform versions (1.8 and older).  It ends support for all interactions with older Platforms, including logging in.

It opens several paths for users:
1. Users can upgrade their platform to 2.0 and use the GETi-SDK 2.0 package with it.
2. Users who decide to stay with an older Platform version can use a corresponding GETi-SDK package.
3. Users with complex pipelines, including model deployments by both legacy and contemporary versions of the Platform, should use separate virtual environments.

SaaS users should not be affected by these changes.