### PR TITLE
Add `model_storage_id` to models when fetching model group

### DIFF
--- a/geti_sdk/rest_clients/model_client.py
+++ b/geti_sdk/rest_clients/model_client.py
@@ -77,6 +77,9 @@ class ModelClient:
             group.algorithm = self.supported_algos.get_by_model_template(
                 model_template_id=group.model_template_id
             )
+            for model in group.models:
+                # set the model storage id, to link models to their parent group
+                model.model_storage_id = group.id
         return model_groups
 
     def get_latest_model_for_all_model_groups(self) -> List[Model]:


### PR DESCRIPTION
This simplifies the interaction with Model objects later on, because it establishes a link to the parent ModelGroup.