### PR TITLE
Update nightly test conda env directory

### DIFF
--- a/.github/workflows/nightly-tests-geti-develop.yaml
+++ b/.github/workflows/nightly-tests-geti-develop.yaml
@@ -19,3 +19,4 @@ jobs:
       GETI_HOST: ${{ secrets.GETI_DEVELOP_HOST }}
       GETI_USERNAME: ${{ secrets.GETI_USERNAME }}
       GETI_PASSWORD: ${{ secrets.GETI_PASSWORD }}
+      CONDA_DIR: ${{ secrets.CONDA_DIR }}

--- a/.github/workflows/nightly-tests-geti-latest.yaml
+++ b/.github/workflows/nightly-tests-geti-latest.yaml
@@ -19,3 +19,4 @@ jobs:
       GETI_HOST: ${{ secrets.GETI_HOST }}
       GETI_USERNAME: ${{ secrets.GETI_USERNAME }}
       GETI_PASSWORD: ${{ secrets.GETI_PASSWORD }}
+      CONDA_DIR: ${{ secrets.CONDA_DIR }}

--- a/.github/workflows/nightly-tests-geti-mvp.yaml
+++ b/.github/workflows/nightly-tests-geti-mvp.yaml
@@ -19,3 +19,4 @@ jobs:
       GETI_HOST: ${{ secrets.GETI_MVP_HOST }}
       GETI_USERNAME: ${{ secrets.GETI_USERNAME }}
       GETI_PASSWORD: ${{ secrets.GETI_PASSWORD }}
+      CONDA_DIR: ${{ secrets.CONDA_DIR }}

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -16,6 +16,8 @@ on:
         required: true
       GETI_PASSWORD:
         required: true
+      CONDA_DIR:
+        required: true
 
 env:
   # Login details for the Geti instance to run the tests against
@@ -35,6 +37,7 @@ env:
 
   # Conda environment
   CONDA_ENV: sc_sdk_nightly_test_environment
+  CONDA_DIR: ${{ secrets.CONDA_DIR }}
   PYTHON_VERSION: 3.9
 
 permissions:
@@ -53,7 +56,7 @@ jobs:
         # Steps: check if env named $CONDA_ENV exists, if so remove it. Create new env
         # using python version $PYTHON_VERSION
         run: |
-          eval "$(conda shell.bash hook)"
+          eval "$($CONDA_DIR/conda shell.bash hook)"
 
           conda info --envs > temp_envs.txt
 

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Install package with dev requirements
         # Steps: Activate conda env, upgrade pip, install SDK
         run: |
-          eval "$(conda shell.bash hook)"
+          eval "$($CONDA_DIR/conda shell.bash hook)"
           conda activate $CONDA_ENV
 
           python -m pip install --upgrade pip
@@ -101,7 +101,7 @@ jobs:
           export NO_PROXY=$GETI_HOST,$NO_PROXY
           export GETI_HOST=https://$GETI_HOST
 
-          eval "$(conda shell.bash hook)"
+          eval "$($CONDA_DIR/conda shell.bash hook)"
           conda activate $CONDA_ENV
 
           pytest tests --cov=geti_sdk --html=$REPORT_DIRECTORY/nightly_test_report.html --self-contained-html --cov-report html:$REPORT_DIRECTORY/coverage


### PR DESCRIPTION
This PR fixes the conda environment activation in the nightly tests after transitioning from `miniconda` to `miniforge`