### PR TITLE
Fix build and publish workflow for internal pypi

### DIFF
--- a/.github/workflows/build-package-internal-pypi.yaml
+++ b/.github/workflows/build-package-internal-pypi.yaml
@@ -11,10 +11,10 @@ permissions:
 
 jobs:
   build:
-    runs-on: [self-hosted, sdk-runner]
     uses: ./.github/workflows/build-package.yaml
     with:
       enable_dev_dependencies: 1
+      runner: self-hosted
     secrets:
       PYPI_USER: ${{ secrets.SCLAB_PYPI_USERNAME }}
       PYPI_PASSWORD: ${{ secrets.SCLAB_PYPI_PASSWORD }}

--- a/.github/workflows/build-package-internal-pypi.yaml
+++ b/.github/workflows/build-package-internal-pypi.yaml
@@ -14,7 +14,7 @@ jobs:
     uses: ./.github/workflows/build-package.yaml
     with:
       enable_dev_dependencies: 1
-      runner: self-hosted
+      runner: sdk-runner
     secrets:
       PYPI_USER: ${{ secrets.SCLAB_PYPI_USERNAME }}
       PYPI_PASSWORD: ${{ secrets.SCLAB_PYPI_PASSWORD }}

--- a/.github/workflows/build-package-internal-pypi.yaml
+++ b/.github/workflows/build-package-internal-pypi.yaml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   build:
+    runs-on: [self-hosted, sdk-runner]
     uses: ./.github/workflows/build-package.yaml
     with:
       enable_dev_dependencies: 1

--- a/.github/workflows/build-package-pypi.yaml
+++ b/.github/workflows/build-package-pypi.yaml
@@ -11,6 +11,7 @@ jobs:
     uses: ./.github/workflows/build-package.yaml
     with:
       enable_dev_dependencies: 0
+      runner: ubuntu-latest
     secrets:
       PYPI_USER: ${{ secrets.PYPI_USERNAME }}
       PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/build-package-test-pypi.yaml
+++ b/.github/workflows/build-package-test-pypi.yaml
@@ -14,6 +14,7 @@ jobs:
     uses: ./.github/workflows/build-package.yaml
     with:
       enable_dev_dependencies: 1
+      runner: ubuntu-latest
     secrets:
       PYPI_USER: ${{ secrets.TEST_PYPI_USERNAME }}
       PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -6,6 +6,9 @@ on:
       enable_dev_dependencies:
         required: false
         type: string
+      runner:
+        required: true
+        type: string
     secrets:
       PYPI_USER:
         required: true
@@ -28,7 +31,7 @@ permissions:
 
 jobs:
   build_sdk:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1


### PR DESCRIPTION
The workflow for publishing a release to the intel-internal pypi needs to run on the self-hosted runner, otherwise it cannot reach the internal pypi server.