### PR TITLE
Fix `is_geti` version check (#434)

### DIFF
--- a/geti_sdk/platform_versions.py
+++ b/geti_sdk/platform_versions.py
@@ -59,18 +59,10 @@ class GetiVersion:
             raise TypeError(
                 f"Unsupported comparison operation, {other} is not a GetiVersion."
             )
-        if self.is_geti and other.is_geti:
-            if self.version != other.version:
-                return self.version > other.version
-            else:
-                return self.time_tag > other.time_tag
+        if self.version != other.version:
+            return self.version > other.version
         else:
-            if self.is_geti and not other.is_geti:
-                return True
-            elif not self.is_geti and other.is_geti:
-                return False
-            else:
-                return self.time_tag > other.time_tag
+            return self.time_tag > other.time_tag
 
     def __lt__(self, other):
         """
@@ -157,18 +149,6 @@ class GetiVersion:
         return (
             self.version == Version("1.1.0")
             and self._SC11_TIMETAG <= self.time_tag <= self._GETI10_TIMETAG
-        )
-
-    @property
-    def is_geti(self) -> bool:
-        """
-        Return True if the version corresponds to any version of the Geti platform.
-        Return False if it corresponds to any SC version.
-        """
-        return (
-            self.version > Version("1.0.0b0")
-            and self.time_tag >= self._GETI10_TIMETAG
-            and not (self.is_sc_1_1 or self.is_sc_mvp)
         )
 
 

--- a/tests/pre-merge/integration/http_session/test_geti_session.py
+++ b/tests/pre-merge/integration/http_session/test_geti_session.py
@@ -32,9 +32,8 @@ class TestGetiSession:
         version_tests = [
             fxt_geti_session.version.is_sc_mvp,
             fxt_geti_session.version.is_sc_1_1,
-            fxt_geti_session.version.is_geti,
         ]
-        assert sum(version_tests) == 1
+        assert sum(version_tests) == 0
 
     @pytest.mark.vcr()
     def test_logout(self, fxt_geti_session: GetiSession):

--- a/tests/pre-merge/unit/test_platform_version_unit.py
+++ b/tests/pre-merge/unit/test_platform_version_unit.py
@@ -12,12 +12,7 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-from geti_sdk.platform_versions import (
-    GETI_10_VERSION,
-    GETI_11_VERSION,
-    SC_11_VERSION,
-    SC_MVP_VERSION,
-)
+from geti_sdk.platform_versions import GETI_10_VERSION, GETI_11_VERSION
 
 
 class TestGetiVersion:
@@ -26,17 +21,5 @@ class TestGetiVersion:
         Test parsing the version from a version string, for different release versions
         of the Intel Geti platform. Also test comparisons between versions
         """
-
-        assert SC_MVP_VERSION.is_sc_mvp and not SC_MVP_VERSION.is_geti
-        assert (
-            SC_11_VERSION.is_sc_1_1
-            and not SC_11_VERSION.is_geti
-            and not SC_11_VERSION.is_sc_mvp
-        )
-        assert GETI_10_VERSION.is_geti
-
-        assert GETI_10_VERSION > SC_11_VERSION
-        assert SC_11_VERSION > SC_MVP_VERSION
-        assert not SC_MVP_VERSION > GETI_10_VERSION
         assert GETI_10_VERSION < GETI_11_VERSION
         assert GETI_11_VERSION >= GETI_10_VERSION


### PR DESCRIPTION
* Fix `is_geti` version check

The SaaS returns a strange build time tag that breaks the version validation.

* Update test_platform_version_unit.py

* Update test_geti_session.py

* Update test_platform_version_unit.py

* Update test_platform_version_unit.py