### PR TITLE
Fix bug in `AsyncVideoProcessor`

### DIFF
--- a/notebooks/014_asynchronous_inference.ipynb
+++ b/notebooks/014_asynchronous_inference.ipynb
@@ -461,7 +461,9 @@
    "source": [
     "You should see clearly now that the frames are not processed in the order of their original index.\n",
     "\n",
-    "Let's set up the `AsyncVideoProcessor` to do the same experiment, and have a look at the processing order again."
+    "Let's set up the `AsyncVideoProcessor` to do the same experiment, and have a look at the processing order again.\n",
+    "\n",
+    "The cell below initializes the AsyncVideoProcessor. "
    ]
   },
   {
@@ -475,11 +477,12 @@
     "\n",
     "# Initialize the processor\n",
     "video_processor = AsyncVideoProcessor(\n",
-    "    deployment=deployment, processing_function=inference_callback\n",
+    "    deployment=deployment,  # Deployment that is used for inference\n",
+    "    processing_function=inference_callback,  # Processing function to apply to each frame, once it is inferred\n",
     ")\n",
     "\n",
     "indices_async_vp: List[int] = []\n",
-    "video_processor.start()\n",
+    "video_processor.start()  # Start the video_processor. This will create a worker thread that listens for video frames to process\n",
     "tstart_async_vp = time.time()\n",
     "for img_index, image_path in enumerate(coco_image_filepaths):\n",
     "    img = cv2.imread(image_path)\n",
@@ -547,7 +550,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d38db933-ccfb-4731-97b1-7da4479e77e1",
+   "id": "68a904d0-6736-4deb-b69a-e7447965d225",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
The time required for fetching items from the OrderedBuffer was measured incorrectly, so it would never time out. This could cause the code to hang indefinitely. This PR fixes the problem.