### PR TITLE
Disable certificate validation for mvtec dataset download

### DIFF
--- a/geti_sdk/demos/data_helpers/anomaly_helpers.py
+++ b/geti_sdk/demos/data_helpers/anomaly_helpers.py
@@ -98,7 +98,9 @@ def get_mvtec_dataset_from_path(dataset_path: str = "data") -> str:
     )
     archive_name = f"{dataset_name}.tar.xz"
     url = f"https://www.mydrive.ch/shares/38536/3830184030e49fe74747669442f0f282/download/420938166-1629953277/{archive_name}"
-    download_file(url, target_folder=dataset_path, check_valid_archive=False)
+    download_file(
+        url, target_folder=dataset_path, check_valid_archive=False, verify_cert=False
+    )
     archive_path = os.path.join(dataset_path, archive_name)
     validate_hash(
         file_path=archive_path,


### PR DESCRIPTION
There is a self-signed certificate in the chain for the target url. This would cause the certificate validation (and hence the download) to fail in some cases.

We still validate the hash of the downloaded file, so not validating the certificate does not introduce a security risk. Also there is no sensitive (user) information exchanged when downloading the file.