### PR TITLE
Create workflow to build wheels for different OS/CPU architecture combinations

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -1,0 +1,78 @@
+name: Build, test and publish wheels
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            cibw_archs: "aarch64"
+          - os: macos-latest
+            cibw_archs: "native arm64"
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          lfs: true
+
+      - name: Set up QEMU [aarch64 only]
+        if: matrix.cibw_archs == 'aarch64'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.19.1
+        env:
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: geti-sdk-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+
+  build_source:
+    name: Build source distribution and pure python wheel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
+        with:
+          python-version: 3.9
+
+      - name: Install package with dev and notebook requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev, notebooks]
+
+      - name: Install build tools
+        run: pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Check package contents
+        run: twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: geti-sdk
+          path: dist

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -12,8 +12,10 @@ jobs:
         include:
           - os: ubuntu-latest
             cibw_archs: "aarch64"
-          - os: macos-latest
-            cibw_archs: "native arm64"
+          - os: macos-13
+            cibw_archs: "x86_64"
+          - os: macos-14
+            cibw_archs: "arm64"
 
     steps:
       - name: Harden Runner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,5 @@ requires = ["setuptools>=66", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-test-command = "pytest tests/pre-merge"
-test-extras = ["dev"]
 # Disable building PyPy wheels on all platforms
 skip = "pp*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
 [build-system]
 requires = ["setuptools>=66", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+test-command = "pytest tests/pre-merge"
+test-extras = ["dev"]
+# Disable building PyPy wheels on all platforms
+skip = "pp*"

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
     ],
     packages=setuptools.find_packages(),
-    python_requires=">=3.9",
+    python_requires=">=3.9,<3.12",
     install_requires=get_requirements("requirements.txt"),
     extras_require={
         "dev": get_requirements("requirements-dev.txt"),


### PR DESCRIPTION
At the moment, installing the geti-sdk on macOS, or on any machine with arm64 architecture will require building datumaro from source. This requires Rust to be installed, which not all of our users may have. This PR is a first step to address this by building wheels for these OS'es and architectures, using the `cibuildwheels` library. It is still experimental, most likely the configuration needs to be tweaked for it to work.

Once building the wheels works, the next step would be to add a job that pulls the artifacts and publishes them to pypi.