### PR TITLE
Update the Model schema to include the `total_disk_size` field 

### DIFF
--- a/geti_sdk/data_models/model.py
+++ b/geti_sdk/data_models/model.py
@@ -96,6 +96,7 @@ class BaseModel:
     label_schema_in_sync: Optional[bool] = attr.field(
         default=None
     )  # Added in Intel Geti 1.1
+    total_disk_size: Optional[int] = None  # Added in Intel Geti 2.3
 
     def __attrs_post_init__(self):
         """


### PR DESCRIPTION
This new field reflects the integral size of the model and all the accompanying files, it is the size that will be freed if the model is purged.