### PR TITLE
Allow Credit System-less servers authenticate with a token

### DIFF
--- a/geti_sdk/rest_clients/credit_system_client.py
+++ b/geti_sdk/rest_clients/credit_system_client.py
@@ -61,9 +61,13 @@ class CreditSystemClient:
 
         :return: True if the Credit System is supported, False otherwise.
         """
+        # Send a GET request to the balance endpoint to check if the Credit System is supported.
+        # The text response is allowed to check if the server responds with a default
+        # html page in case the Credit System is not supported.
         r = self.session.get_rest_response(
             url=self.session.base_url + "balance",
             method="GET",
+            allow_text_response=True,
         )
         if isinstance(r, dict):
             # If the Platform responds with the information about the available subscriptions,


### PR DESCRIPTION
The servers with the Credit System disabled return an empty 200 response when called with a cookie and an HTML page when called with an API token.
This PR adds support for both cases. 