### PR TITLE
Project access refactoring

### DIFF
--- a/examples/upload_and_predict_from_numpy.py
+++ b/examples/upload_and_predict_from_numpy.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     rotated_image = rotate_image(image=numpy_image, angle=20)
 
     # Make sure that the project exists
-    ensure_trained_example_project(geti=geti, project_name=PROJECT_NAME)
+    project = ensure_trained_example_project(geti=geti, project_name=PROJECT_NAME)
 
     print(
         "Uploading and predicting example image now... The prediction results will be "
@@ -71,7 +71,7 @@ if __name__ == "__main__":
 
     # We can upload and predict the resulting array directly:
     sc_image, image_prediction = geti.upload_and_predict_image(
-        project_name=PROJECT_NAME,
+        project=project,
         image=rotated_image,
         visualise_output=False,
         delete_after_prediction=DELETE_AFTER_PREDICTION,
@@ -100,7 +100,7 @@ if __name__ == "__main__":
     print("Video generated, retrieving predictions...")
     # Create video, upload and predict from the list of frames
     sc_video, video_frames, frame_predictions = geti.upload_and_predict_video(
-        project_name=PROJECT_NAME,
+        project=project,
         video=rotation_video,
         frame_stride=1,
         visualise_output=False,

--- a/examples/upload_and_predict_media_from_folder.py
+++ b/examples/upload_and_predict_media_from_folder.py
@@ -38,11 +38,11 @@ if __name__ == "__main__":
     # --------------------------------------------------
 
     # Make sure that the specified project exists on the server
-    ensure_trained_example_project(geti=geti, project_name=PROJECT_NAME)
+    project = ensure_trained_example_project(geti=geti, project_name=PROJECT_NAME)
 
     # Upload the media in the folder and generate predictions
     geti.upload_and_predict_media_folder(
-        project_name=PROJECT_NAME,
+        project=project,
         media_folder=FOLDER_WITH_MEDIA,
         delete_after_prediction=DELETE_AFTER_PREDICTION,
         output_folder=OUTPUT_FOLDER,

--- a/geti_sdk/benchmarking/benchmarker.py
+++ b/geti_sdk/benchmarking/benchmarker.py
@@ -498,7 +498,7 @@ class Benchmarker:
                 output_folder = os.path.join(working_directory, f"deployment_{index}")
                 with suppress_log_output():
                     self.geti.deploy_project(
-                        project_name=self.project.name,
+                        project=self.project,
                         output_folder=output_folder,
                         models=opt_models,
                     )

--- a/geti_sdk/benchmarking/benchmarker.py
+++ b/geti_sdk/benchmarking/benchmarker.py
@@ -53,7 +53,7 @@ class Benchmarker:
     def __init__(
         self,
         geti: Geti,
-        project: Union[str, Project],
+        project: Project,
         precision_levels: Optional[Sequence[str]] = None,
         models: Optional[Sequence[Model]] = None,
         algorithms: Optional[Sequence[str]] = None,
@@ -83,7 +83,7 @@ class Benchmarker:
         be called after initialization.
 
         :param geti: Geti instance on which the project to use for benchmarking lives
-        :param project: Project or project name to use for the benchmarking. The
+        :param project: Project to use for the benchmarking. The
             project must exist on the specified Geti instance
         :param precision_levels: List of model precision levels to run the
             benchmarking for. Throughput will be measured for each precision level
@@ -111,11 +111,8 @@ class Benchmarker:
             on.
         """
         self.geti = geti
-        if isinstance(project, str):
-            project_name = project
-        else:
-            project_name = project.name
-        self.project = geti.get_project(project_name)
+        # Update project object to get the latest project details
+        self.project = self.geti.get_project(project_id=project.id)
         logging.info(
             f"Setting up Benchmarker for Intel® Geti™ project `{self.project.name}`."
         )

--- a/geti_sdk/geti.py
+++ b/geti_sdk/geti.py
@@ -263,12 +263,14 @@ class Geti:
         If no project by that name is found on the Intel® Geti™ server,
         this method will raise a KeyError.
 
-        :param project_name: Name of the project to retrieve
+        :param project_name: Name of the project to retrieve.
         :param project_id: ID of the project to retrieve. If not specified, the
             project with name `project_name` will be retrieved.
-        :param project: Project object to update. If not specified, the project with
-        :raises: KeyError if project named `project_name` is not found on the server
-        :return: Project identified by `project_name`
+        :param project: Project object to update. If provided, the associated `project_id`
+            will be used to update the project object.
+        :raises: KeyError if the project identified by one of the arguments is not found on the server
+        :raises: ValueError if there are several projects on the server named `project_name`
+        :return: Project identified by one of the arguments.
         """
         project = self.project_client.get_project(
             project_name=project_name, project_id=project_id, project=project

--- a/geti_sdk/geti.py
+++ b/geti_sdk/geti.py
@@ -1051,7 +1051,7 @@ class Geti:
         extraction. Predictions are only generated for the extracted frames. So to
         get predictions for all frames, `frame_stride=1` can be passed.
 
-        :param project: Project object to upload the video to
+        :param project: Project to upload the video to
         :param video: Video or filepath to a video to upload and get predictions for.
             Can also be a 4D numpy array or a list of 3D numpy arrays, shaped such
             that the array dimensions represent `frames x width x height x channels`,

--- a/geti_sdk/import_export/import_export_module.py
+++ b/geti_sdk/import_export/import_export_module.py
@@ -433,8 +433,7 @@ class GetiIE:
         logging.info(
             f"Project '{project_name}' was successfully imported from the dataset."
         )
-        imported_project = self.project_client.get_project_by_name(
-            project_name=project_name,
+        imported_project = self.project_client.get_project(
             project_id=job.metadata.project_id,
         )
         if imported_project is None:
@@ -479,8 +478,7 @@ class GetiIE:
         )
 
         job = monitor_job(session=self.session, job=job, interval=5)
-        imported_project = self.project_client.get_project_by_name(
-            project_name=project_name,
+        imported_project = self.project_client.get_project(
             project_id=job.metadata.project_id,
         )
         if imported_project is None:

--- a/geti_sdk/import_export/import_export_module.py
+++ b/geti_sdk/import_export/import_export_module.py
@@ -75,7 +75,7 @@ class GetiIE:
 
         # Download project creation parameters:
         self.project_client.download_project_info(
-            project_name=project.name, path_to_folder=target_folder
+            project=project, path_to_folder=target_folder
         )
 
         # Download images

--- a/geti_sdk/import_export/import_export_module.py
+++ b/geti_sdk/import_export/import_export_module.py
@@ -280,7 +280,7 @@ class GetiIE:
         return project
 
     def download_all_projects(
-        self, target_folder: str, include_predictions: bool = True
+        self, target_folder: str = "./projects", include_predictions: bool = True
     ) -> List[Project]:
         """
         Download all projects from the Geti Platform.
@@ -293,8 +293,6 @@ class GetiIE:
         projects = self.project_client.get_all_projects()
 
         # Validate or create target_folder
-        if target_folder is None:
-            target_folder = os.path.join(".", "projects")
         os.makedirs(target_folder, exist_ok=True, mode=0o770)
         logging.info(
             f"Found {len(projects)} projects in the designated workspace on the "
@@ -505,7 +503,7 @@ class GetiIE:
         )
         tus_uploader.upload()
         file_id = tus_uploader.get_file_id()
-        if file_id is None or len(file_id) < 2:
+        if file_id is None:
             raise RuntimeError("Failed to get file id for project {project_name}.")
         return file_id
 

--- a/geti_sdk/import_export/import_export_module.py
+++ b/geti_sdk/import_export/import_export_module.py
@@ -330,7 +330,7 @@ class GetiIE:
         project_folders = [
             folder
             for folder in candidate_project_folders
-            if ProjectClient.is_project_dir(folder)
+            if ProjectClient._is_project_dir(folder)
         ]
         logging.info(
             f"Found {len(project_folders)} project data folders in the target "

--- a/geti_sdk/import_export/tus_uploader.py
+++ b/geti_sdk/import_export/tus_uploader.py
@@ -169,9 +169,14 @@ class TUSUploader:
 
         :return: File id.
         """
-        if self.upload_url is None:
+        if (
+            self.upload_url is None
+            or len(file_id := self.upload_url.split("/")[-1]) < 2
+        ):
+            # We get the file_id from the upload url. If the url is not set or the file_id
+            # is not valid (may be an empty string if the url is not valid), we return None.
             return
-        return self.upload_url.split("/")[-1]
+        return file_id
 
     def upload_chunk(self):
         """

--- a/geti_sdk/rest_clients/project_client/project_client.py
+++ b/geti_sdk/rest_clients/project_client/project_client.py
@@ -117,7 +117,7 @@ class ProjectClient:
         Get a project from the Intel® Geti™ server by project_name.
 
         If multiple projects with the same name exist on the server, this method will
-        raise a ValueError, unless a `project_id` is provided to uniquely identify the
+        raise a ValueError. In that case, please use the `ProjectClient.get_project()` method and provide a `project_id` to uniquely identify the project
         project.
 
         :param project_name: Name of the project to get

--- a/geti_sdk/rest_clients/project_client/project_client.py
+++ b/geti_sdk/rest_clients/project_client/project_client.py
@@ -135,8 +135,8 @@ class ProjectClient:
                 ]
                 projects_info = [
                     (
-                        f"Name: {p.name}, Type: {p.project_type}, ID: {p.id}, "
-                        f"creation_date: {p.creation_time}"
+                        f"Name: {p.name},\t Type: {p.project_type},\t ID: {p.id},\t "
+                        f"creation_date: {p.creation_time}\n"
                     )
                     for p in detailed_matches
                 ]

--- a/geti_sdk/rest_clients/project_client/project_client.py
+++ b/geti_sdk/rest_clients/project_client/project_client.py
@@ -117,8 +117,8 @@ class ProjectClient:
         Get a project from the Intel® Geti™ server by project_name.
 
         If multiple projects with the same name exist on the server, this method will
-        raise a ValueError. In that case, please use the `ProjectClient.get_project()` method and provide a `project_id` to uniquely identify the project
-        project.
+        raise a ValueError. In that case, please use the `ProjectClient.get_project()`
+        method and provide a `project_id` to uniquely identify the project.
 
         :param project_name: Name of the project to get
         :raises: ValueError in case multiple projects with the specified name exist on

--- a/notebooks/001_create_project.ipynb
+++ b/notebooks/001_create_project.ipynb
@@ -225,7 +225,7 @@
    "id": "aa289ae0-36bb-40db-afb3-d1c89fb2a9e1",
    "metadata": {},
    "source": [
-    "The `project` object that was created by the `project_client.create_project()` method can also be retrieved by calling `project_client.get_project_by_name()`. This is useful if you do not want to create a new project, but would like to interact with an existing project instead"
+    "The `project` object that was created by the `project_client.create_project()` method can also be retrieved by calling `project_client.get_project()`. This is useful if you do not want to create a new project, but would like to interact with an existing project instead"
    ]
   },
   {
@@ -235,7 +235,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "project = project_client.get_project_by_name(project_name=PROJECT_NAME)\n",
+    "project = project_client.get_project(project_name=PROJECT_NAME)\n",
     "print(project.summary)"
    ]
   },
@@ -395,7 +395,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/003_upload_and_predict_image.ipynb
+++ b/notebooks/003_upload_and_predict_image.ipynb
@@ -84,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "project = project_client.get_project_by_name(PROJECT_NAME)\n",
+    "project = project_client.get_project(project_name=PROJECT_NAME)\n",
     "image_client = ImageClient(\n",
     "    session=geti.session, workspace_id=geti.workspace_id, project=project\n",
     ")\n",

--- a/notebooks/005_modify_image.ipynb
+++ b/notebooks/005_modify_image.ipynb
@@ -116,7 +116,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "project = project_client.get_project_by_name(project_name=\"COCO horse detection demo\")"
+    "project = project_client.get_project(project_name=\"COCO horse detection demo\")"
    ]
   },
   {

--- a/notebooks/006_reconfigure_task.ipynb
+++ b/notebooks/006_reconfigure_task.ipynb
@@ -48,7 +48,7 @@
     "PROJECT_NAME = \"COCO multitask animal demo\"\n",
     "projects = project_client.list_projects()\n",
     "\n",
-    "project = project_client.get_project_by_name(PROJECT_NAME)"
+    "project = project_client.get_project(PROJECT_NAME)"
    ]
   },
   {
@@ -233,7 +233,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/007_train_project.ipynb
+++ b/notebooks/007_train_project.ipynb
@@ -65,7 +65,7 @@
    "source": [
     "PROJECT_NAME = \"COCO multitask animal demo\"\n",
     "\n",
-    "project = project_client.get_project_by_name(project_name=PROJECT_NAME)"
+    "project = project_client.get_project(project_name=PROJECT_NAME)"
    ]
   },
   {
@@ -297,7 +297,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.17"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/011_benchmarking_models.ipynb
+++ b/notebooks/011_benchmarking_models.ipynb
@@ -44,7 +44,7 @@
    "outputs": [],
    "source": [
     "PROJECT_NAME = \"COCO animal detection demo\"\n",
-    "project = geti.get_project(PROJECT_NAME)"
+    "project = geti.get_project(project_name=PROJECT_NAME)"
    ]
   },
   {

--- a/notebooks/014_asynchronous_inference.ipynb
+++ b/notebooks/014_asynchronous_inference.ipynb
@@ -55,7 +55,7 @@
     "geti = Geti(server_config=geti_server_configuration)\n",
     "\n",
     "PROJECT_NAME = \"COCO multitask animal demo\"\n",
-    "project = geti.get_project(PROJECT_NAME)"
+    "project = geti.get_project(project_name=PROJECT_NAME)"
    ]
   },
   {

--- a/tests/fixtures/demos.py
+++ b/tests/fixtures/demos.py
@@ -62,9 +62,8 @@ def fxt_anomaly_classification_demo_project(
     )
     yield project
     force_delete_project(
-        project_name=project_name,
+        project,
         project_client=fxt_project_client_no_vcr,
-        project_id=project.id,
     )
 
 
@@ -87,9 +86,8 @@ def fxt_segmentation_demo_project(
     )
     yield project
     force_delete_project(
-        project_name=project.name,
+        project,
         project_client=fxt_project_client_no_vcr,
-        project_id=project.id,
     )
 
 
@@ -112,9 +110,8 @@ def fxt_detection_to_classification_demo_project(
     )
     yield project
     force_delete_project(
-        project_name=project.name,
+        project,
         project_client=fxt_project_client_no_vcr,
-        project_id=project.id,
     )
 
 
@@ -137,9 +134,8 @@ def fxt_detection_to_segmentation_demo_project(
     )
     yield project
     force_delete_project(
-        project_name=project_name,
+        project,
         project_client=fxt_project_client_no_vcr,
-        project_id=project.id,
     )
 
 
@@ -162,9 +158,8 @@ def fxt_classification_demo_project(
     )
     yield project
     force_delete_project(
-        project_name=project_name,
+        project,
         project_client=fxt_project_client_no_vcr,
-        project_id=project.id,
     )
 
 
@@ -187,9 +182,8 @@ def fxt_detection_demo_project(
     )
     yield project
     force_delete_project(
-        project_name=project_name,
+        project,
         project_client=fxt_project_client_no_vcr,
-        project_id=project.id,
     )
 
 

--- a/tests/fixtures/projects.py
+++ b/tests/fixtures/projects.py
@@ -98,8 +98,8 @@ def fxt_project_finalizer(fxt_project_client: ProjectClient) -> Callable[[str], 
     :var project_name: Name of the project for which to add the finalizer
     """
 
-    def _project_finalizer(project_name: str, project_id: str) -> None:
-        force_delete_project(project_name, fxt_project_client, project_id)
+    def _project_finalizer(project: Project, project_id: str) -> None:
+        force_delete_project(project, fxt_project_client)
 
     return _project_finalizer
 

--- a/tests/fixtures/projects.py
+++ b/tests/fixtures/projects.py
@@ -98,7 +98,7 @@ def fxt_project_finalizer(fxt_project_client: ProjectClient) -> Callable[[str], 
     :var project_name: Name of the project for which to add the finalizer
     """
 
-    def _project_finalizer(project: Project, project_id: str) -> None:
+    def _project_finalizer(project: Project) -> None:
         force_delete_project(project, fxt_project_client)
 
     return _project_finalizer

--- a/tests/fixtures/unit_tests/benchmarker.py
+++ b/tests/fixtures/unit_tests/benchmarker.py
@@ -27,18 +27,17 @@ def fxt_benchmarker(
     fxt_mocked_geti: Geti,
 ) -> Benchmarker:
     _ = mocker.patch(
-        "geti_sdk.geti.ProjectClient.get_project_by_name",
+        "geti_sdk.geti.Geti.get_project",
         return_value=fxt_classification_project,
     )
     _ = mocker.patch("geti_sdk.benchmarking.benchmarker.ModelClient")
     _ = mocker.patch("geti_sdk.benchmarking.benchmarker.TrainingClient")
-    project_name = "project name"
     algorithms_to_benchmark = ("ALGO_1", "ALGO_2")
     precision_levels = ("PRECISION_1", "PRECISION_2")
     images = ("path_1", "path_2")
     yield Benchmarker(
         geti=fxt_mocked_geti,
-        project=project_name,
+        project=mocker.MagicMock(),
         algorithms=algorithms_to_benchmark,
         precision_levels=precision_levels,
         benchmark_images=images,
@@ -52,7 +51,7 @@ def fxt_benchmarker_task_chain(
     fxt_mocked_geti: Geti,
 ) -> Benchmarker:
     _ = mocker.patch(
-        "geti_sdk.geti.ProjectClient.get_project_by_name",
+        "geti_sdk.geti.Geti.get_project",
         return_value=fxt_detection_to_classification_project,
     )
     model_client_object_mock = mocker.MagicMock()
@@ -64,13 +63,12 @@ def fxt_benchmarker_task_chain(
     model_client_object_mock.get_all_active_models.return_value = active_models
 
     _ = mocker.patch("geti_sdk.benchmarking.benchmarker.TrainingClient")
-    project_name = "project name"
     precision_levels = ("PRECISION_1", "PRECISION_2")
     images = ("path_1", "path_2")
 
     yield Benchmarker(
         geti=fxt_mocked_geti,
-        project=project_name,
+        project=mocker.MagicMock(),
         precision_levels=precision_levels,
         benchmark_images=images,
     )

--- a/tests/helpers/finalizers.py
+++ b/tests/helpers/finalizers.py
@@ -13,14 +13,12 @@
 # and limitations under the License.
 import logging
 import time
-from typing import Optional
 
+from geti_sdk.data_models.project import Project
 from geti_sdk.rest_clients import ProjectClient, TrainingClient
 
 
-def force_delete_project(
-    project_name: str, project_client: ProjectClient, project_id: Optional[str] = None
-) -> None:
+def force_delete_project(project: Project, project_client: ProjectClient) -> None:
     """
     Deletes the project named 'project_name'. If any jobs are running for the
     project, this finalizer cancels them.
@@ -30,17 +28,16 @@ def force_delete_project(
     :param project_id: Optional ID of the project to delete. This can be useful in case
         there are multiple projects with the same name in the workspace
     """
-    project = project_client.get_project_by_name(project_name, project_id)
     try:
         project_client.delete_project(project=project, requires_confirmation=False)
     except TypeError:
         logging.warning(
-            f"Project {project_name} was not found on the server, it was most "
+            f"Project {project.name} was not found on the server, it was most "
             f"likely already deleted."
         )
     except ValueError:
         logging.error(
-            f"Unable to delete project '{project_name}' from the server, it "
+            f"Unable to delete project '{project.name}' from the server, it "
             f"is most likely locked for deletion due to an operation/training "
             f"session that is in progress. "
             f"\n\n Attempting to cancel the job and re-try project deletion."

--- a/tests/helpers/project_helpers.py
+++ b/tests/helpers/project_helpers.py
@@ -94,7 +94,7 @@ def remove_all_test_projects(geti: Geti) -> List[str]:
     projects_removed: List[str] = []
     for project in project_client.get_all_projects(get_project_details=False):
         if project.name.startswith(PROJECT_PREFIX):
-            force_delete_project(project.name, project_client, project_id=project.id)
+            force_delete_project(project, project_client)
             projects_removed.append(project.name)
     logging.info(f"{len(projects_removed)} test projects were removed from the server.")
     return projects_removed

--- a/tests/helpers/project_service.py
+++ b/tests/helpers/project_service.py
@@ -334,9 +334,7 @@ class ProjectService:
         """Deletes the project from the server"""
         if self._project is not None:
             with self.vcr_context(f"{self.project.name}_deletion.{CASSETTE_EXTENSION}"):
-                force_delete_project(
-                    self.project.name, self.project_client, self.project.id
-                )
+                force_delete_project(self.project, self.project_client)
                 self.reset_state()
 
     def reset_state(self) -> None:

--- a/tests/nightly/demos/test_demo_projects.py
+++ b/tests/nightly/demos/test_demo_projects.py
@@ -160,9 +160,8 @@ class TestDemoProjects:
         )
         if any_project is not None:
             force_delete_project(
-                project_name=non_existing_project_name,
+                project=any_project,
                 project_client=fxt_project_client_no_vcr,
-                project_id=any_project.id,
             )
         assert non_existing_project_name not in [
             project.name for project in fxt_project_client_no_vcr.get_all_projects()

--- a/tests/nightly/test_anomaly_classification.py
+++ b/tests/nightly/test_anomaly_classification.py
@@ -23,9 +23,8 @@ class TestAnomalyClassification(TestNightlyProject):
         existing_project = fxt_project_client_no_vcr.get_project_by_name(project_name)
         if existing_project is not None:
             force_delete_project(
-                project_name=project_name,
+                project=existing_project,
                 project_client=fxt_project_client_no_vcr,
-                project_id=existing_project.id,
             )
         assert project_name not in [
             project.name for project in fxt_project_client_no_vcr.get_all_projects()

--- a/tests/nightly/test_classification.py
+++ b/tests/nightly/test_classification.py
@@ -89,7 +89,8 @@ class TestClassification(TestNightlyProject):
         # Project is exported
         assert not os.path.exists(archive_path)
         fxt_geti_no_vcr.export_project(
-            project_name=project.name, project_id=project.id, filepath=archive_path
+            filepath=archive_path,
+            project=project,
         )
         assert os.path.exists(archive_path)
 

--- a/tests/nightly/test_nightly_project.py
+++ b/tests/nightly/test_nightly_project.py
@@ -127,7 +127,7 @@ class TestNightlyProject:
         for j in range(n_attempts):
             try:
                 image, prediction = fxt_geti_no_vcr.upload_and_predict_image(
-                    project_name=project.name,
+                    project=project,
                     image=fxt_image_path,
                     visualise_output=False,
                     delete_after_prediction=False,
@@ -160,7 +160,7 @@ class TestNightlyProject:
 
         deployment_folder = os.path.join(fxt_temp_directory, project.name)
         deployment = fxt_geti_no_vcr.deploy_project(
-            project.name,
+            project,
             output_folder=deployment_folder,
             enable_explainable_ai=True,
         )
@@ -177,7 +177,7 @@ class TestNightlyProject:
             local_prediction = deployment.infer(image_np)
             assert isinstance(local_prediction, Prediction)
             image, online_prediction = fxt_geti_no_vcr.upload_and_predict_image(
-                project.name,
+                project,
                 image=image_bgr,
                 delete_after_prediction=True,
                 visualise_output=False,

--- a/tests/pre-merge/integration/test_geti.py
+++ b/tests/pre-merge/integration/test_geti.py
@@ -209,7 +209,7 @@ class TestGeti:
             max_threads=1,
         )
 
-        request.addfinalizer(lambda: fxt_project_finalizer(project_name, project.id))
+        request.addfinalizer(lambda: fxt_project_finalizer(project))
 
     @pytest.mark.vcr()
     @pytest.mark.parametrize(
@@ -257,7 +257,7 @@ class TestGeti:
             enable_auto_train=False,
             max_threads=1,
         )
-        request.addfinalizer(lambda: fxt_project_finalizer(project_name, project.id))
+        request.addfinalizer(lambda: fxt_project_finalizer(project))
 
         all_labels = fxt_default_labels + ["block"]
         for label_name in all_labels:
@@ -304,9 +304,7 @@ class TestGeti:
             enable_auto_train=False,
             max_threads=1,
         )
-        request.addfinalizer(
-            lambda: fxt_project_finalizer(uploaded_project.name, uploaded_project.id)
-        )
+        request.addfinalizer(lambda: fxt_project_finalizer(uploaded_project))
         image_client = ImageClient(
             session=fxt_geti.session,
             workspace_id=fxt_geti.workspace_id,

--- a/tests/pre-merge/integration/test_geti.py
+++ b/tests/pre-merge/integration/test_geti.py
@@ -287,7 +287,7 @@ class TestGeti:
         target_folder = os.path.join(fxt_temp_directory, project.name)
 
         fxt_geti.download_project_data(
-            project.name,
+            project,
             target_folder=target_folder,
             max_threads=1,
         )
@@ -393,7 +393,7 @@ class TestGeti:
         for j in range(n_attempts):
             try:
                 image, prediction = fxt_geti.upload_and_predict_image(
-                    project_name=project.name,
+                    project=project,
                     image=fxt_image_path,
                     visualise_output=False,
                     delete_after_prediction=False,
@@ -419,7 +419,7 @@ class TestGeti:
         Verify that the `Geti.upload_and_predict_video` method works as expected
         """
         video, frames, predictions = fxt_geti.upload_and_predict_video(
-            project_name=fxt_project_service.project.name,
+            project=fxt_project_service.project,
             video=fxt_video_path_1_light_bulbs,
             visualise_output=False,
         )
@@ -432,15 +432,16 @@ class TestGeti:
 
         # Check that invalid project raises a KeyError
         with pytest.raises(KeyError):
+            project = fxt_geti.get_project(project_name="invalid_project_name")
             fxt_geti.upload_and_predict_video(
-                project_name="invalid_project_name",
+                project=project,
                 video=fxt_video_path_1_light_bulbs,
                 visualise_output=False,
             )
 
         # Check that video is not uploaded if it's already in the project
         video, frames, predictions = fxt_geti.upload_and_predict_video(
-            project_name=fxt_project_service.project.name,
+            project=fxt_project_service.project,
             video=video,
             visualise_output=False,
         )
@@ -450,7 +451,7 @@ class TestGeti:
         new_frames = video.to_frames(frame_stride=50, include_data=True)
         np_frames = [frame.numpy for frame in new_frames]
         np_video, frames, predictions = fxt_geti.upload_and_predict_video(
-            project_name=fxt_project_service.project.name,
+            project=fxt_project_service.project,
             video=np_frames,
             visualise_output=False,
             delete_after_prediction=True,
@@ -475,14 +476,14 @@ class TestGeti:
         image_output_folder = os.path.join(fxt_temp_directory, "inferred_images")
 
         video_success = fxt_geti.upload_and_predict_media_folder(
-            project_name=fxt_project_service.project.name,
+            project=fxt_project_service.project,
             media_folder=fxt_video_folder_light_bulbs,
             output_folder=video_output_folder,
             delete_after_prediction=True,
             max_threads=1,
         )
         image_success = fxt_geti.upload_and_predict_media_folder(
-            project_name=fxt_project_service.project.name,
+            project=fxt_project_service.project,
             media_folder=fxt_image_folder_light_bulbs,
             output_folder=image_output_folder,
             delete_after_prediction=True,
@@ -519,7 +520,7 @@ class TestGeti:
         for _ in range(n_attempts):
             try:
                 deployment = fxt_geti.deploy_project(
-                    project.name,
+                    project,
                     output_folder=deployment_folder,
                     enable_explainable_ai=True,
                 )
@@ -538,7 +539,7 @@ class TestGeti:
         local_prediction = deployment.infer(image_np)
         assert isinstance(local_prediction, Prediction)
         image, online_prediction = fxt_geti.upload_and_predict_image(
-            project.name,
+            project,
             image=image_np,
             delete_after_prediction=True,
             visualise_output=False,
@@ -577,7 +578,7 @@ class TestGeti:
         project = fxt_project_service.project
         deployment_folder = os.path.join(fxt_temp_directory, project.name)
 
-        deployment = fxt_geti.deploy_project(project.name)
+        deployment = fxt_geti.deploy_project(project)
         dataset_name = "Test hooks"
 
         # Add a GetiDataCollectionHook
@@ -670,7 +671,7 @@ class TestGeti:
             fxt_temp_directory, project.name + "_all_inclusive"
         )
         fxt_geti.download_project_data(
-            project_name=project.name,
+            project=project,
             target_folder=target_folder,
             include_predictions=True,
             include_active_models=True,

--- a/tests/pre-merge/unit/benchmarking/test_benchmarker.py
+++ b/tests/pre-merge/unit/benchmarking/test_benchmarker.py
@@ -32,8 +32,8 @@ class TestBenchmarker:
         mocker: MockerFixture,
     ):
         # Arrange
-        mock_get_project_by_name = mocker.patch(
-            "geti_sdk.geti.ProjectClient.get_project_by_name",
+        mock_get_project = mocker.patch(
+            "geti_sdk.geti.Geti.get_project",
             return_value=fxt_classification_project,
         )
         mocked_model_client = mocker.patch(
@@ -42,7 +42,7 @@ class TestBenchmarker:
         mocked_training_client = mocker.patch(
             "geti_sdk.benchmarking.benchmarker.TrainingClient"
         )
-        project_name = "project name"
+        project_mock = mocker.MagicMock()
         algorithms_to_benchmark = ("ALGO_1", "ALGO_2")
         precision_levels = ("PRECISION_1", "PRECISION_2")
         images = ("path_1", "path_2")
@@ -52,14 +52,14 @@ class TestBenchmarker:
         # Single task project, benchmarking on images
         benchmarker = Benchmarker(
             geti=fxt_mocked_geti,
-            project=project_name,
+            project=project_mock,
             algorithms=algorithms_to_benchmark,
             precision_levels=precision_levels,
             benchmark_images=images,
         )
 
         # Assert
-        mock_get_project_by_name.assert_called_once_with(project_name=project_name)
+        mock_get_project.assert_called_once_with(project_id=project_mock.id)
         mocked_model_client.assert_called_once()
         mocked_training_client.assert_called_once()
         assert benchmarker._is_single_task
@@ -72,7 +72,7 @@ class TestBenchmarker:
         with pytest.raises(ValueError):
             benchmarker = Benchmarker(
                 geti=fxt_mocked_geti,
-                project=project_name,
+                project=project_mock,
                 algorithms=algorithms_to_benchmark,
                 precision_levels=precision_levels,
                 benchmark_images=images,
@@ -86,8 +86,8 @@ class TestBenchmarker:
         mocker: MockerFixture,
     ):
         # Arrange
-        mock_get_project_by_name = mocker.patch(
-            "geti_sdk.geti.ProjectClient.get_project_by_name",
+        mocker.patch(
+            "geti_sdk.geti.Geti.get_project",
             return_value=fxt_detection_to_classification_project,
         )
         fetched_images = (mocker.MagicMock(),)
@@ -106,19 +106,18 @@ class TestBenchmarker:
         mocked_training_client = mocker.patch(
             "geti_sdk.benchmarking.benchmarker.TrainingClient"
         )
-        project_name = "project name"
+        project_mock = mocker.MagicMock()
         precision_levels = ["PRECISION_1", "PRECISION_2"]
 
         # Act
         # Multi task project, no media provided
         benchmarker = Benchmarker(
             geti=fxt_mocked_geti,
-            project=project_name,
+            project=project_mock,
             precision_levels=precision_levels,
         )
 
         # Assert
-        mock_get_project_by_name.assert_called_once_with(project_name=project_name)
         mock_image_client_get_all.assert_called_once()
         mocked_model_client.assert_called_once()
         model_client_object_mock.get_all_active_models.assert_called_once()

--- a/tests/pre-merge/unit/benchmarking/test_benchmarker.py
+++ b/tests/pre-merge/unit/benchmarking/test_benchmarker.py
@@ -59,9 +59,7 @@ class TestBenchmarker:
         )
 
         # Assert
-        mock_get_project_by_name.assert_called_once_with(
-            project_name=project_name, project_id=None
-        )
+        mock_get_project_by_name.assert_called_once_with(project_name=project_name)
         mocked_model_client.assert_called_once()
         mocked_training_client.assert_called_once()
         assert benchmarker._is_single_task
@@ -120,9 +118,7 @@ class TestBenchmarker:
         )
 
         # Assert
-        mock_get_project_by_name.assert_called_once_with(
-            project_name=project_name, project_id=None
-        )
+        mock_get_project_by_name.assert_called_once_with(project_name=project_name)
         mock_image_client_get_all.assert_called_once()
         mocked_model_client.assert_called_once()
         model_client_object_mock.get_all_active_models.assert_called_once()

--- a/tests/pre-merge/unit/test_geti_unit.py
+++ b/tests/pre-merge/unit/test_geti_unit.py
@@ -173,7 +173,7 @@ class TestGeti:
         for project in fxt_nightly_projects:
             os.makedirs(os.path.join(target_dir, project.name))
         mock_is_project_dir = mocker.patch(
-            "geti_sdk.geti.ProjectClient.is_project_dir", return_value=True
+            "geti_sdk.geti.ProjectClient._is_project_dir", return_value=True
         )
         mock_upload_project_data = mocker.patch(
             "geti_sdk.import_export.import_export_module.GetiIE.upload_project_data"


### PR DESCRIPTION
This PR adds guardrails to the user workflow that should streamline the experience of working with identically named projects.
The `get_project` now may be called with one of [project_name, project_id, project_object].
Fetching a project by name now has an unraveled logic scheme and is THE place where the user can determine the correct `project_id`.
All the other methods now accept a project object as an argument instead of a project_name which may be potentially problematic.
