### PR TITLE
Keep label ID's intact on saving project deployment

### DIFF
--- a/geti_sdk/deployment/deployment.py
+++ b/geti_sdk/deployment/deployment.py
@@ -129,7 +129,7 @@ class Deployment:
         :param path_to_folder: Folder to save the deployment to
         :return: True if the deployment was saved successfully, False otherwise
         """
-        project_dict = ProjectRESTConverter.to_dict(self.project)
+        project_dict = ProjectRESTConverter.to_dict(self.project, deidentify=False)
         deployment_folder = os.path.join(path_to_folder, "deployment")
 
         os.makedirs(deployment_folder, exist_ok=True, mode=0o770)

--- a/geti_sdk/rest_converters/project_rest_converter.py
+++ b/geti_sdk/rest_converters/project_rest_converter.py
@@ -44,7 +44,7 @@ class ProjectRESTConverter:
         return deserialize_dictionary(prepared_project, output_type=Project)
 
     @classmethod
-    def to_dict(cls, project: Project) -> Dict[str, Any]:
+    def to_dict(cls, project: Project, deidentify: bool = True) -> Dict[str, Any]:
         """
         Convert the `project` to its dictionary representation.
         This functions removes database UID's and optional fields that are `None`
@@ -52,9 +52,13 @@ class ProjectRESTConverter:
         readability.
 
         :param project: Project to convert to dictionary
+        :param deidentify: True to remove all unique database ID's from the project
+            and it's child entities, False to keep the ID's intact. Defaults to True,
+            which is useful for project import/export
         :return:
         """
-        project.deidentify()
+        if deidentify:
+            project.deidentify()
         project_data = project.to_dict()
         remove_null_fields(project_data)
         return project_data


### PR DESCRIPTION
This fixes an issue in which the label ID <-> name matching failed for deployments that were saved to disk