### PR TITLE
Project deployment by name

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -138,7 +138,7 @@ This code sample shows how to get a deployment from the server.
 > geti = Geti(server_config=server_config)
 >
 > # Create deployment for the project, and prepare it for running inference
-> deployment = geti.deploy_project(PROJECT_NAME)
+> deployment = geti.deploy_project(project_name=PROJECT_NAME)
 >
 > # Save deployment on local
 > deployment.save(PATH_TO_DEPLOYMENT)

--- a/geti_sdk/geti.py
+++ b/geti_sdk/geti.py
@@ -371,7 +371,7 @@ class Geti:
         # Download deployment
         if include_deployment:
             logging.info("Creating deployment for project...")
-            self.deploy_project(project, output_folder=target_folder)
+            self.deploy_project(project=project, output_folder=target_folder)
 
         logging.info(f"Project '{project.name}' was downloaded successfully.")
         return project
@@ -1132,7 +1132,8 @@ class Geti:
 
     def deploy_project(
         self,
-        project: Project,
+        project: Optional[Project] = None,
+        project_name: Optional[str] = None,
         output_folder: Optional[Union[str, os.PathLike]] = None,
         models: Optional[Sequence[BaseModel]] = None,
         enable_explainable_ai: bool = False,
@@ -1147,7 +1148,10 @@ class Geti:
         for each task in the project. However, it is possible to specify a particular
         model to use, by passing it in the list of `models` as input to this method.
 
-        :param project: Project object to deploy
+        :param project: Project object to deploy. Either `project` or `project_name`
+            must be specified.
+        :param project_name: Name of the project to deploy. Either `project` or
+            `project_name` must be specified.
         :param output_folder: Path to a folder on local disk to which the Deployment
             should be downloaded. If no path is specified, the deployment will not be
             saved.
@@ -1165,6 +1169,11 @@ class Geti:
             launch an OVMS container serving the models.
         :return: Deployment for the project
         """
+        if project is None and project_name is None:
+            raise ValueError("Either `project` or `project_name` must be specified.")
+        if project is None:
+            project = self.project_client.get_project_by_name(project_name=project_name)
+
         deployment_client = self._deployment_clients.get(project.id, None)
         if deployment_client is None:
             # Create deployment client and add to cache.

--- a/notebooks/012_post_inference_hooks.ipynb
+++ b/notebooks/012_post_inference_hooks.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "deployment = geti.deploy_project(PROJECT_NAME)"
+    "deployment = geti.deploy_project(project=project)"
    ]
   },
   {
@@ -101,8 +101,8 @@
    "source": [
     "import cv2\n",
     "\n",
-    "from geti_sdk.demos import EXAMPLE_IMAGE_PATH\n",
     "from geti_sdk import Visualizer\n",
+    "from geti_sdk.demos import EXAMPLE_IMAGE_PATH\n",
     "\n",
     "numpy_image = cv2.imread(EXAMPLE_IMAGE_PATH)\n",
     "numpy_rgb = cv2.cvtColor(numpy_image, cv2.COLOR_BGR2RGB)\n",

--- a/notebooks/014_asynchronous_inference.ipynb
+++ b/notebooks/014_asynchronous_inference.ipynb
@@ -75,7 +75,9 @@
    "source": [
     "DEPLOYMENT_FOLDER = \"deployments\"\n",
     "\n",
-    "deployment = geti.deploy_project(PROJECT_NAME, output_folder=DEPLOYMENT_FOLDER)"
+    "deployment = geti.deploy_project(\n",
+    "    project_name=PROJECT_NAME, output_folder=DEPLOYMENT_FOLDER\n",
+    ")"
    ]
   },
   {

--- a/tests/nightly/test_nightly_project.py
+++ b/tests/nightly/test_nightly_project.py
@@ -160,7 +160,7 @@ class TestNightlyProject:
 
         deployment_folder = os.path.join(fxt_temp_directory, project.name)
         deployment = fxt_geti_no_vcr.deploy_project(
-            project,
+            project=project,
             output_folder=deployment_folder,
             enable_explainable_ai=True,
         )

--- a/tests/pre-merge/integration/test_geti.py
+++ b/tests/pre-merge/integration/test_geti.py
@@ -518,7 +518,7 @@ class TestGeti:
         for _ in range(n_attempts):
             try:
                 deployment = fxt_geti.deploy_project(
-                    project,
+                    project=project,
                     output_folder=deployment_folder,
                     enable_explainable_ai=True,
                 )
@@ -576,7 +576,7 @@ class TestGeti:
         project = fxt_project_service.project
         deployment_folder = os.path.join(fxt_temp_directory, project.name)
 
-        deployment = fxt_geti.deploy_project(project)
+        deployment = fxt_geti.deploy_project(project=project)
         dataset_name = "Test hooks"
 
         # Add a GetiDataCollectionHook


### PR DESCRIPTION
Fixes: CVS-156929

Notebooks and examples show that you can deploy projects by their name but this was not implemented. Notebooks 12 and 14 would not run successful because of this.

This PR fixes that by requiring either the project object or the project name in the Geti.deploy_project() method. 