### PR TITLE
Bug Fix - Notebooks using project_name instead of project for a few methods

### DIFF
--- a/notebooks/003_upload_and_predict_image.ipynb
+++ b/notebooks/003_upload_and_predict_image.ipynb
@@ -239,7 +239,7 @@
    "outputs": [],
    "source": [
     "quick_image, quick_prediction = geti.upload_and_predict_image(\n",
-    "    project_name=PROJECT_NAME,\n",
+    "    project=project,\n",
     "    image=EXAMPLE_IMAGE_PATH,\n",
     "    visualise_output=False,\n",
     "    delete_after_prediction=False,\n",

--- a/notebooks/008_deploy_project.ipynb
+++ b/notebooks/008_deploy_project.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "from geti_sdk.demos import ensure_trained_example_project\n",
     "\n",
-    "ensure_trained_example_project(geti=geti, project_name=PROJECT_NAME);"
+    "project = ensure_trained_example_project(geti=geti, project_name=PROJECT_NAME);"
    ]
   },
   {
@@ -106,9 +106,7 @@
    "id": "0d17e98e-ac6c-4353-9282-23c2e20835d3",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "deployment = geti.deploy_project(project_name=PROJECT_NAME, enable_explainable_ai=True)"
-   ]
+   "source": "deployment = geti.deploy_project(project=project, enable_explainable_ai=True)"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/008_deploy_project.ipynb
+++ b/notebooks/008_deploy_project.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "from geti_sdk.demos import ensure_trained_example_project\n",
     "\n",
-    "project = ensure_trained_example_project(geti=geti, project_name=PROJECT_NAME);"
+    "ensure_trained_example_project(geti=geti, project_name=PROJECT_NAME);"
    ]
   },
   {
@@ -106,7 +106,9 @@
    "id": "0d17e98e-ac6c-4353-9282-23c2e20835d3",
    "metadata": {},
    "outputs": [],
-   "source": "deployment = geti.deploy_project(project=project, enable_explainable_ai=True)"
+   "source": [
+    "deployment = geti.deploy_project(project_name=PROJECT_NAME, enable_explainable_ai=True)"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/notebooks/009_download_and_upload_project.ipynb
+++ b/notebooks/009_download_and_upload_project.ipynb
@@ -76,7 +76,7 @@
     "## Project download\n",
     "Now, let's do the project download itself. The `Geti` provides a method `download_project_data()` to do so. It takes the following arguments:\n",
     "\n",
-    "- `project_name`: Name of the project to download\n",
+    "- `project`: The project to download\n",
     "- `target_folder`: Path of the folder to download to. If left empty, a folder named `project_name` will be created in the current directory\n",
     "- `include_predictions`: True to download predictions for all media, False to not download any predictions\n",
     "- `include_active_models`: True to download the active models for all tasks in the project, False to not download any models\n",

--- a/notebooks/009_download_and_upload_project.ipynb
+++ b/notebooks/009_download_and_upload_project.ipynb
@@ -94,8 +94,9 @@
    "source": [
     "import os\n",
     "\n",
-    "project = geti.download_project_data(\n",
-    "    project_name=PROJECT_NAME,\n",
+    "project = project_client.get_project_by_name(project_name=PROJECT_NAME)\n",
+    "geti.download_project_data(\n",
+    "    project=project,\n",
     "    target_folder=os.path.join(\"projects\", PROJECT_NAME),\n",
     "    include_predictions=False,\n",
     "    include_active_models=False,\n",


### PR DESCRIPTION
A few notebooks  passed the project_name parameter for methods download_project_data() and upload_and_predict_image(). These methods required "project" object. 

In such notebooks, since the project object is already created and available, the function calls have been updated.

