### PR TITLE
Fix VCR config for unset proxy

### DIFF
--- a/tests/fixtures/vcr_config.py
+++ b/tests/fixtures/vcr_config.py
@@ -44,6 +44,7 @@ def vcr_record_config(
             proxy_hosts = [
                 proxy.replace("http://", "").replace("https://", "").split(":")[0]
                 for proxy in fxt_server_config.proxies.values()
+                if proxy is not None
             ]
         yield {"record_mode": RecordMode.NONE, "ignore_hosts": [host] + proxy_hosts}
     elif fxt_test_mode == SdkTestMode.OFFLINE:


### PR DESCRIPTION
The function would raise an error (`None` has no method `replace`) when you configure only one proxy, e.g. `https_proxy` but not `http_proxy`.