### PR TITLE
(CVS-159908) fixed missing no_object label when constructing LabelList in PredictionConverter

### DIFF
--- a/geti_sdk/deployment/predictions_postprocessing/results_converter/results_to_prediction_converter.py
+++ b/geti_sdk/deployment/predictions_postprocessing/results_converter/results_to_prediction_converter.py
@@ -51,7 +51,7 @@ class InferenceResultsToPredictionConverter(metaclass=abc.ABCMeta):
     def __init__(
         self, labels: LabelList, configuration: Optional[Dict[str, Any]] = None
     ):
-        self.labels = labels.get_non_empty_labels()
+        self.labels = labels
         self.empty_label = labels.get_empty_label()
         self.configuration = configuration
 


### PR DESCRIPTION
I am unsure if this is the correct place to fix this. I had to create a quick hotfix for deployments in SaaS.