### PR TITLE
CVS-160100 - Deprecate HPO

### DIFF
--- a/geti_sdk/data_models/algorithms.py
+++ b/geti_sdk/data_models/algorithms.py
@@ -37,7 +37,7 @@ class Algorithm:
     task_type: Optional[str] = attr.field(
         default=None, converter=str_to_optional_enum_converter(TaskType)
     )
-    supports_auto_hpo: Optional[bool] = None
+    supports_auto_hpo: Optional[bool] = None  # Deprecated in Geti v2.7
     default_algorithm: Optional[bool] = None  # Added in Geti v1.16
     performance_category: Optional[str] = None  # Added in Geti v1.9
     lifecycle_stage: Optional[str] = None  # Added in Geti v1.9

--- a/geti_sdk/data_models/configurable_parameter.py
+++ b/geti_sdk/data_models/configurable_parameter.py
@@ -74,8 +74,6 @@ class ConfigurableParameter:
     )
     ui_rules: Optional[Dict[str, Any]] = None
     warning: Optional[str] = None
-    auto_hpo_state: Optional[str] = None
-    auto_hpo_value: Optional[Union[str, bool, float, int]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """

--- a/geti_sdk/data_models/configurable_parameter.py
+++ b/geti_sdk/data_models/configurable_parameter.py
@@ -27,6 +27,8 @@ from geti_sdk.data_models.utils import (
     str_to_enum_converter,
 )
 
+DEPRECATED_PARAMETERS = ["auto_hpo_state", "auto_hpo_value"]
+
 
 @attr.define
 class ConfigurableParameter:

--- a/geti_sdk/data_models/configurable_parameter_group.py
+++ b/geti_sdk/data_models/configurable_parameter_group.py
@@ -59,11 +59,11 @@ def _parameter_dicts_to_list(
     """
     parameters: List[PARAMETER_TYPES] = []
     for parameter in parameter_dicts:
-        if parameter in DEPRECATED_PARAMETERS:
-            continue
         if isinstance(parameter, get_args(PARAMETER_TYPES)):
             parameters.append(parameter)
             continue
+        for deprecated_key in DEPRECATED_PARAMETERS:
+            parameter.pop(deprecated_key, None)
         data_type = parameter.get("data_type", None)
         template_type = parameter.get("template_type", None)
         if data_type is None or template_type is None:

--- a/geti_sdk/data_models/configurable_parameter_group.py
+++ b/geti_sdk/data_models/configurable_parameter_group.py
@@ -18,6 +18,7 @@ from typing import Any, ClassVar, Dict, List, Optional, Sequence, Type, Union, g
 import attr
 
 from geti_sdk.data_models.configurable_parameter import (
+    DEPRECATED_PARAMETERS,
     ConfigurableBoolean,
     ConfigurableFloat,
     ConfigurableInteger,
@@ -145,6 +146,8 @@ class ParameterGroup:
             input_dict
         """
         input_copy = copy.deepcopy(input_dict)
+        for deprecated_key in DEPRECATED_PARAMETERS:
+            input_copy.pop(deprecated_key, None)
         parameter_dicts: List[Union[Dict[str, Any], ConfigurableParameter]] = (
             input_copy.pop("parameters", [])
         )

--- a/geti_sdk/data_models/configurable_parameter_group.py
+++ b/geti_sdk/data_models/configurable_parameter_group.py
@@ -59,6 +59,8 @@ def _parameter_dicts_to_list(
     """
     parameters: List[PARAMETER_TYPES] = []
     for parameter in parameter_dicts:
+        if parameter in DEPRECATED_PARAMETERS:
+            continue
         if isinstance(parameter, get_args(PARAMETER_TYPES)):
             parameters.append(parameter)
             continue

--- a/geti_sdk/data_models/configuration.py
+++ b/geti_sdk/data_models/configuration.py
@@ -17,6 +17,7 @@ from typing import Any, ClassVar, Dict, List, Optional, Union
 import attr
 
 from geti_sdk.data_models import Algorithm
+from geti_sdk.data_models.configurable_parameter import DEPRECATED_PARAMETERS
 from geti_sdk.data_models.configurable_parameter_group import (
     PARAMETER_TYPES,
     ParameterGroup,
@@ -162,6 +163,9 @@ class Configuration:
         :param name: Name of the parameter to get
         :return: ConfigurableParameter object
         """
+        if name in DEPRECATED_PARAMETERS:
+            return None
+
         parameters = [config.get_parameter_by_name(name) for config in self.components]
         parameters = [parameter for parameter in parameters if parameter is not None]
         if len(parameters) == 0:

--- a/geti_sdk/rest_clients/training_client.py
+++ b/geti_sdk/rest_clients/training_client.py
@@ -160,8 +160,8 @@ class TrainingClient:
         :param train_from_scratch: True to train the model from scratch, False to
             continue training from an existing checkpoint (if any)
         :param hyper_parameters: Optional hyper parameters to use for training
-        :param hpo_parameters: Optional set of parameters to use for automatic hyper
-            parameter optimization. Only supported for version 1.1 and up
+        :param hpo_parameters: [Deprecated] Optional set of parameters to use for automatic hyper
+            parameter optimization.
         :param await_running_jobs: True to wait for currently running jobs to
             complete. This will guarantee that the training request can be submitted
             successfully. Setting this to False will cause an error to be raised when
@@ -199,11 +199,8 @@ class TrainingClient:
             )
             request_data.update({"hyper_parameters": hypers_rest})
         if hpo_parameters is not None:
-            request_data.update(
-                {
-                    "enable_hyper_parameter_optimization": True,
-                    "hpo_parameters": hpo_parameters,
-                }
+            logging.warning(
+                "`hpo_parameters` have been deprecated and will be ignored."
             )
 
         request_data.pop("dataset_id")


### PR DESCRIPTION
[CVS-160100](https://jira.devtools.intel.com/browse/CVS-160100)

HPO will be deprecated in Geti 2.7, impact on the REST API:

Deprecated parameters:

- `supports_auto_hpo` from the supported algorithm endpoint response
- `enable_hyper_parameter_optimization` and `hpo_parameters` from training endpoint request

Removed parameters:

- `auto_hpo_state` and `auto_hpo_value` are removed from project configuration endpoint response