### PR TITLE
Add support for Python 3.12 and update CI Ubuntu version

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: Install package with dev, notebooks and docs requirements
         run: |

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: Install package with dev and notebook requirements
         run: |

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload wheel and source files as github artifact
         # Publish the built wheel and source tarball to github
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         if: ${{ always() }}
         with:
           name: geti_sdk

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: Install package with dev and notebook requirements
         run: |

--- a/.github/workflows/pre-merge-tests.yml
+++ b/.github/workflows/pre-merge-tests.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload test report for pre-merge tests
         # Publish the test report to github
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         if: ${{ always() }}
         with:
           name: pre-merge-test-reports

--- a/.github/workflows/pre-merge-tests.yml
+++ b/.github/workflows/pre-merge-tests.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:  # Run test with legacy cassette (Currently - Geti 2.0)
           - os: ubuntu-22.04

--- a/.github/workflows/pre-merge-tests.yml
+++ b/.github/workflows/pre-merge-tests.yml
@@ -28,7 +28,7 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:  # Run test with legacy cassette (Currently - Geti 2.0)
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: '3.10'
             env: GETI_PLATFORM_VERSION=LEGACY
       fail-fast: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -64,7 +64,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     
     - name: Install dependencies
       run: python -m pip install pip-tools
@@ -88,7 +88,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install Bandit
         run: pip install bandit
       - name: Bandit scan (report)
@@ -114,7 +114,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install Bandit
         run: pip install bandit
       - name: Bandit scan (high severity)

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   Trivy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@c95a14d0e5bab51a9f56296a4eb0e416910cd350 # v2.10.3
@@ -76,7 +76,7 @@ jobs:
         retention-days: 7
 
   Bandit-all:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@c95a14d0e5bab51a9f56296a4eb0e416910cd350 # v2.10.3
@@ -102,7 +102,7 @@ jobs:
           retention-days: 7
 
   Bandit-high:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@c95a14d0e5bab51a9f56296a4eb0e416910cd350 # v2.10.3
@@ -122,7 +122,7 @@ jobs:
 
   CodeQL:
     name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       # required for all workflows
       security-events: write
@@ -180,7 +180,7 @@ jobs:
   Summarize:
     needs: [Trivy, Bandit-all, CodeQL]
     if: always()
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@c95a14d0e5bab51a9f56296a4eb0e416910cd350 # v2.10.3

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.9"
+    python: "3.12"
     # You can also specify other tool versions:
     # nodejs: "19"
     # rust: "1.64"

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ highly recommended.
 Make sure to set up your environment using one of the supported Python versions for your
 operating system, as indicated in the table below.
 
-|             | Python <= 3.8 | Python 3.9         | Python 3.10        | Python 3.11        | Python 3.12 |
-|:------------|:-------------:|:------------------:|:------------------:|:------------------:|:-----------:|
-| **Linux**   | :x:           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:         |
-| **Windows** | :x:           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:         |
-| **MacOS**   | :x:           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:         |
+|             | Python <= 3.8 | Python 3.9         | Python 3.10        | Python 3.11        | Python 3.12        | Python 3.13 |
+|:------------|:-------------:|:------------------:|:------------------:|:------------------:|:------------------:|:-----------:|
+| **Linux**   | :x:           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:         |
+| **Windows** | :x:           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:         |
+| **MacOS**   | :x:           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:         |
 
 Once you have created and activated a new environment, follow the steps below to install
 the package.

--- a/geti_sdk/data_models/configurable_parameter_group.py
+++ b/geti_sdk/data_models/configurable_parameter_group.py
@@ -47,7 +47,7 @@ PARAMETER_TYPES = Union[
 
 
 def _parameter_dicts_to_list(
-    parameter_dicts: List[Union[Dict[str, Any], PARAMETER_TYPES]]
+    parameter_dicts: List[Union[Dict[str, Any], PARAMETER_TYPES]],
 ) -> List[PARAMETER_TYPES]:
     """
     Convert a list of dictionary representations of configurable parameters to a

--- a/geti_sdk/data_models/utils.py
+++ b/geti_sdk/data_models/utils.py
@@ -184,7 +184,7 @@ def str_to_shape_type(shape_type: Union[str, ShapeType]) -> ShapeType:
 
 
 def str_to_annotation_kind(
-    annotation_kind: Union[str, AnnotationKind]
+    annotation_kind: Union[str, AnnotationKind],
 ) -> AnnotationKind:
     """
     Convert an input string to an annotation kind.

--- a/geti_sdk/demos/data_helpers/video_helpers.py
+++ b/geti_sdk/demos/data_helpers/video_helpers.py
@@ -24,7 +24,7 @@ VIDEO_PERSON_CAR_BIKE_PATH = os.path.join(
 
 
 def get_person_car_bike_video(
-    video_path: Optional[Union[str, os.PathLike]] = None
+    video_path: Optional[Union[str, os.PathLike]] = None,
 ) -> str:
     """
     Get the path to the 'person-bicycle-car-detection.mp4' video file that is used for

--- a/geti_sdk/rest_clients/prediction_client.py
+++ b/geti_sdk/rest_clients/prediction_client.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
+import base64
 import io
 import json
 import logging
@@ -247,7 +248,7 @@ class PredictionClient:
                         map = ResultMedium(
                             name="saliency_map", label_id=map_dict.get("label_id", None)
                         )
-                        map.data = map_dict["data"].encode("utf-8")
+                        map.data = base64.b64decode(map_dict["data"])
                         maps.append(map)
                     result.maps = maps
                 result.resolve_labels_for_result_media(labels=self._labels)

--- a/geti_sdk/rest_converters/configuration_rest_converter.py
+++ b/geti_sdk/rest_converters/configuration_rest_converter.py
@@ -84,7 +84,7 @@ class ConfigurationRESTConverter:
 
     @staticmethod
     def _rest_components_to_objects(
-        input_list: List[Dict[str, Any]]
+        input_list: List[Dict[str, Any]],
     ) -> List[ConfigurableParameters]:
         """
         Create a list of configurable parameters from a list of dictionaries received
@@ -183,7 +183,7 @@ class ConfigurationRESTConverter:
 
     @staticmethod
     def global_configuration_from_rest(
-        input_: Union[List[Dict[str, Any]], Dict[str, Any]]
+        input_: Union[List[Dict[str, Any]], Dict[str, Any]],
     ) -> GlobalConfiguration:
         """
         Create a GlobalConfiguration object holding the configurable parameters

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
     ],
     packages=setuptools.find_packages(),
-    python_requires=">=3.9,<3.12",
+    python_requires=">=3.9,<3.13",
     install_requires=get_requirements("requirements.txt"),
     extras_require={
         "dev": get_requirements("requirements-dev.txt"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions
 # and limitations under the License.
-""" This module defines the test configuration """
+"""This module defines the test configuration"""
 import logging
 import os
 import shutil

--- a/tests/fixtures/geti.py
+++ b/tests/fixtures/geti.py
@@ -71,7 +71,7 @@ def fxt_geti(
 
 @pytest.fixture(scope="module")
 def fxt_geti_no_vcr(
-    fxt_server_config: Union[ServerTokenConfig, ServerCredentialConfig]
+    fxt_server_config: Union[ServerTokenConfig, ServerCredentialConfig],
 ) -> Geti:
     if isinstance(fxt_server_config, ServerCredentialConfig):
         auth_params = {

--- a/tests/fixtures/vcr_config.py
+++ b/tests/fixtures/vcr_config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-""" Configuration fixtures for VCR """
+"""Configuration fixtures for VCR"""
 import os
 from typing import Any, Dict
 

--- a/tests/pre-merge/unit/deployment/test_prediction_converter.py
+++ b/tests/pre-merge/unit/deployment/test_prediction_converter.py
@@ -45,7 +45,7 @@ from geti_sdk.deployment.predictions_postprocessing.results_converter.results_to
 
 
 def coords_to_xmin_xmax_width_height(
-    coords: Tuple[int, int, int, int]
+    coords: Tuple[int, int, int, int],
 ) -> Tuple[int, int, int, int]:
     "Convert bbox to xmin, ymin, width, height format"
     x1, y1, x2, y2 = coords


### PR DESCRIPTION
This PR updates the CI with Python 3.12 support.

I have also fixed a bug whereby saliency images where saved as base64 instead of raw jpg.

I have also bump the version of upload-artifact as v3 is deprecated and does not work anymore.