### PR TITLE
bugfix: swapped color channels when visualizing prediction sample (notebook 10)

### DIFF
--- a/notebooks/010_model_serving.ipynb
+++ b/notebooks/010_model_serving.ipynb
@@ -14,10 +14,12 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "c9baafb1-4be1-427e-8665-2e9a4d377142",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "# As usual we will connect to the platform first, using the server details from the .env file\n",
     "\n",
@@ -27,9 +29,7 @@
     "geti_server_configuration = get_server_details_from_env()\n",
     "\n",
     "geti = Geti(server_config=geti_server_configuration)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -42,18 +42,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "608a8fb7-24b8-45ee-aff8-e3044d236756",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "from geti_sdk.rest_clients import ProjectClient\n",
     "\n",
     "project_client = ProjectClient(session=geti.session, workspace_id=geti.workspace_id)\n",
     "projects = project_client.list_projects()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -66,15 +66,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "8b748042-6d21-471a-8acd-d3f360d543e3",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "PROJECT_NAME = \"COCO animal detection demo\""
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -88,17 +88,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "ffd5fb89-f4a2-4398-9951-8b1cefa4ab99",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "from geti_sdk.demos import ensure_trained_example_project\n",
     "\n",
     "ensure_trained_example_project(geti=geti, project_name=PROJECT_NAME);"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -110,10 +110,12 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "0d17e98e-ac6c-4353-9282-23c2e20835d3",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "import os\n",
     "\n",
@@ -130,9 +132,7 @@
     "deployment = geti.deploy_project(\n",
     "    project_name=PROJECT_NAME, prepare_ovms_config=True, output_folder=output_folder\n",
     ")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -160,15 +160,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "84599e9f-4597-4449-b7ec-d33d6132487a",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "! docker pull openvino/model_server:latest"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -181,15 +181,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "7395a5c9-29ae-4778-a884-0b2fbb7d90ba",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "ovms_config_path = os.path.join(os.getcwd(), output_folder, \"ovms_models\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -201,15 +201,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "5171e2ed-4144-4970-9e56-f8447db16a86",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "! docker run -d --rm -v {ovms_config_path}:/models -p 9000:9000 openvino/model_server:latest --port 9000 --config_path /models/ovms_model_config.json"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -223,15 +223,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "2cd18ef9-4eb8-4094-9f47-e58bf051e7bb",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "deployment.load_inference_models(device=\"http://localhost:9000\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -247,10 +247,12 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "df3dbf77-b18b-4d86-9787-513ee9d1f328",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "import time\n",
     "\n",
@@ -268,9 +270,7 @@
     "t_elapsed = time.time() - t_start\n",
     "\n",
     "print(f\"Running OVMS inference on image took {t_elapsed*1000:.2f} milliseconds\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -288,19 +288,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "2dde3d0c-aa3a-4635-b76c-df5c6f033de2",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "from geti_sdk import Visualizer\n",
     "\n",
     "visualizer = Visualizer()\n",
-    "result = visualizer.draw(numpy_image, prediction)\n",
+    "result = visualizer.draw(numpy_rgb, prediction)\n",
     "visualizer.show_in_notebook(result)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -313,31 +313,31 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "ffa3c911-af19-418d-8220-c85e4d907453",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "deployment.load_inference_models(device=\"CPU\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "8bbdf5ae-b282-411b-afc3-c6a390cccb9a",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "t_start = time.time()\n",
     "prediction = deployment.infer(numpy_rgb)\n",
     "t_elapsed = time.time() - t_start\n",
     "\n",
     "print(f\"Running local inference on image took {t_elapsed*1000:.2f} milliseconds\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -355,18 +355,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "73fabe19-5a55-451d-a54f-e250c449e9a8",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "%%timeit -n 10 -r 3\n",
     "\n",
     "# CPU inference\n",
     "prediction = deployment.infer(numpy_rgb)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -378,30 +378,30 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "62339ec9-c1cf-4a85-86b4-809f35580237",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "deployment.load_inference_models(device=\"http://localhost:9000\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "41da1af8-672d-4ccb-ae34-4ed3f44b9be5",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "%%timeit -n 10 -r 3\n",
     "\n",
     "# OVMS inference\n",
     "prediction = deployment.infer(numpy_rgb)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -422,15 +422,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "9171f158-1354-4214-a220-8c86e0487150",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "MULTITASK_PROJECT_NAME = \"COCO multitask animal demo\""
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -442,24 +442,26 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "b6819f77-de78-4c2b-bcda-57b096dd6278",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "mt_project = ensure_trained_example_project(\n",
     "    geti=geti, project_name=MULTITASK_PROJECT_NAME\n",
     ")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "691904af-5603-4486-86d2-386b86abd298",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "safe_mt_project_name = sanitize_filepath(MULTITASK_PROJECT_NAME).replace(\" \", \"_\")\n",
     "\n",
@@ -472,9 +474,7 @@
     "    prepare_ovms_config=True,\n",
     "    output_folder=mt_output_folder,\n",
     ")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -488,17 +488,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "e0ca9c4d-a904-4d9a-bf42-5c84d83cf0a3",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "mt_ovms_config_path = os.path.join(os.getcwd(), mt_output_folder, \"ovms_models\")\n",
     "\n",
     "! docker run -d --rm -v {mt_ovms_config_path}:/models -p 9001:9001 openvino/model_server:latest --port 9001 --config_path /models/ovms_model_config.json"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -511,15 +511,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "0645f97a-6088-45b3-87f0-f17666d3623e",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "multitask_deployment.load_inference_models(device=\"http://localhost:9001\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -531,10 +531,12 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "f2accc67-7f40-4b63-8000-590df1acb9dd",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "t_start = time.time()\n",
     "prediction = multitask_deployment.infer(numpy_rgb)\n",
@@ -544,9 +546,7 @@
     "\n",
     "result = visualizer.draw(numpy_rgb, prediction)\n",
     "visualizer.show_in_notebook(result)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -559,18 +559,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "65f55ff1-f2ca-4b2d-9dbe-d4e09d6c2b35",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "%%timeit -n 10 -r 3\n",
     "\n",
     "# OVMS inference\n",
     "prediction = multitask_deployment.infer(numpy_rgb)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -582,15 +582,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "26681cc5-fc42-4412-8ea5-af5d57201c37",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "multitask_deployment.load_inference_models(device=\"CPU\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -602,18 +602,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "f9e99d51-aed0-44a4-b1cc-a3939370eab7",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "%%timeit -n 10 -r 3\n",
     "\n",
     "# CPU inference\n",
     "prediction = multitask_deployment.infer(numpy_rgb)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -640,18 +640,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "0c5cca6b-fedf-4fe6-bcb2-e3afeadefbbd",
    "metadata": {
     "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
+   "outputs": [],
    "source": [
     "container_ids = ! docker ps -q --filter ancestor=openvino/model_server\n",
     "\n",
     "print(f\"Found {len(container_ids)} running OVMS containers.\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -666,11 +666,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "80fc7bf9-1b9d-477a-b9e0-45a4a554c70f",
    "metadata": {
     "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
+   "outputs": [],
    "source": [
     "# Stop each container\n",
     "for ovms_container_id in container_ids:\n",
@@ -680,9 +682,7 @@
     "        print(f\"OVMS container '{ovms_container_id}' stopped and removed successfully.\")\n",
     "    else:\n",
     "        print(result[0])"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -714,7 +714,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
`Visualizer` expects a RGB image as input