### PR TITLE
Improve automatic workspace selection [2.7]

### DIFF
--- a/geti_sdk/geti.py
+++ b/geti_sdk/geti.py
@@ -52,8 +52,8 @@ from .rest_clients import (
 )
 from .utils import (
     generate_classification_labels,
-    get_default_workspace_id,
     get_task_types_by_project_type,
+    get_workspace_id,
     show_image_with_annotation_scene,
     show_video_frames_with_annotation_scenes,
 )
@@ -186,7 +186,7 @@ class Geti:
         self._check_platform_version()
         # Get workspace ID
         if workspace_id is None:
-            workspace_id = get_default_workspace_id(self.session)
+            workspace_id = get_workspace_id(self.session)
         self.workspace_id = workspace_id
         self.project_client = ProjectClient(
             workspace_id=workspace_id, session=self.session

--- a/geti_sdk/rest_clients/credit_system_client.py
+++ b/geti_sdk/rest_clients/credit_system_client.py
@@ -21,7 +21,7 @@ from geti_sdk.data_models.job import Job, JobCost
 from geti_sdk.http_session import GetiSession
 from geti_sdk.utils.job_helpers import get_job_by_id
 from geti_sdk.utils.serialization_helpers import deserialize_dictionary
-from geti_sdk.utils.workspace_helpers import get_default_workspace_id
+from geti_sdk.utils.workspace_helpers import get_workspace_id
 
 
 def allow_supported(func):
@@ -51,7 +51,7 @@ class CreditSystemClient:
         if workspace_id is not None:
             self.workspace_id = workspace_id
         else:
-            self.workspace_id = get_default_workspace_id(self.session)
+            self.workspace_id = get_workspace_id(self.session)
         # Make sure the Intel Geti Platform supports Credit System.
         self._is_supported = self.is_supported()
 

--- a/geti_sdk/utils/__init__.py
+++ b/geti_sdk/utils/__init__.py
@@ -36,10 +36,10 @@ from .plot_helpers import (
 )
 from .project_helpers import get_project_folder_name, get_task_types_by_project_type
 from .serialization_helpers import deserialize_dictionary
-from .workspace_helpers import get_default_workspace_id
+from .workspace_helpers import get_workspace_id
 
 __all__ = [
-    "get_default_workspace_id",
+    "get_workspace_id",
     "generate_classification_labels",
     "generate_segmentation_labels",
     "get_dict_key_from_value",

--- a/tests/fixtures/unit_tests/geti.py
+++ b/tests/fixtures/unit_tests/geti.py
@@ -71,7 +71,7 @@ def fxt_mocked_session_factory(
 
 @pytest.fixture
 def fxt_mocked_geti(mocker: MockerFixture, fxt_mocked_session_factory):
-    mocker.patch("geti_sdk.geti.get_default_workspace_id", return_value=1)
+    mocker.patch("geti_sdk.geti.get_workspace_id", return_value=1)
     mocker.patch("geti_sdk.geti.GetiSession", new=fxt_mocked_session_factory)
     geti = Geti(host="dummy_host", password="dummy_password", username="dummy_username")
 

--- a/tests/pre-merge/unit/test_geti_unit.py
+++ b/tests/pre-merge/unit/test_geti_unit.py
@@ -35,7 +35,7 @@ class TestGeti:
         # Arrange
         mocker.patch("geti_sdk.geti.GetiSession", new=fxt_mocked_session_factory)
         mock_get_workspace_id = mocker.patch(
-            "geti_sdk.geti.get_default_workspace_id", return_value=1
+            "geti_sdk.geti.get_workspace_id", return_value=1
         )
 
         # Act and assert
@@ -114,7 +114,7 @@ class TestGeti:
         # Arrange
         mocker.patch("geti_sdk.geti.GetiSession", new=fxt_mocked_session_factory)
         mock_session = fxt_mocked_session_factory()
-        mocker.patch("geti_sdk.geti.get_default_workspace_id", return_value=1)
+        mocker.patch("geti_sdk.geti.get_workspace_id", return_value=1)
         # Decrease the minor version for the SDK
         platform_version = str(mock_session.version.version).split(".")
         mocker.patch(


### PR DESCRIPTION
This PR fixes an issue with the automatic selection of the workspace. The previous logic, based on hardcoded names, is replaced by a more reliable algorithm: if there is only one workspace to choose from, that is automatically selected; if there are 2+, then the user must pick one explicitly (through the `workspace_id` parameter) otherwise the SDK throws an error.