### PR TITLE
CVS-163037 - Fix inference converter

### DIFF
--- a/geti_sdk/deployment/predictions_postprocessing/results_converter/results_to_prediction_converter.py
+++ b/geti_sdk/deployment/predictions_postprocessing/results_converter/results_to_prediction_converter.py
@@ -58,7 +58,7 @@ class InferenceResultsToPredictionConverter(metaclass=abc.ABCMeta):
         model_api_labels = (
             [model_api_labels]
             if isinstance(model_api_labels, str)
-            else model_api_labels
+            else [str(name) for name in model_api_labels]
         )
         # Create a mapping of label ID to label objects
         self.label_map_ids = {}

--- a/tests/pre-merge/unit/deployment/test_prediction_converter.py
+++ b/tests/pre-merge/unit/deployment/test_prediction_converter.py
@@ -321,6 +321,7 @@ class TestInferenceResultsToPredictionConverter:
                 ["a", "b", "c"],
                 {"labels": ["c", "b", "a", "empty"]},
             ),
+            (["1"], ["1"], ["1"], {"labels": [1]}),
         ],
     )
     def test_legacy_label_conversion(


### PR DESCRIPTION
Fix bug: If a project has label names like 1, the model returns labels as list[int] instead of list[str], which the converter class does not expect.