### PR TITLE
Remove an old check on the deployed model version

### DIFF
--- a/geti_sdk/deployment/deployed_model.py
+++ b/geti_sdk/deployment/deployed_model.py
@@ -29,7 +29,6 @@ from model_api.adapters import OpenvinoAdapter, OVMSAdapter
 from model_api.models import Model as model_api_Model
 from model_api.tilers import DetectionTiler, InstanceSegmentationTiler, Tiler
 from openvino.runtime import Core
-from packaging.version import Version
 
 from geti_sdk.data_models import OptimizedModel, Project, TaskConfiguration
 from geti_sdk.data_models.containers import LabelList
@@ -45,13 +44,11 @@ from geti_sdk.rest_converters import ConfigurationRESTConverter, ModelRESTConver
 from .utils import (
     generate_ovms_model_address,
     generate_ovms_model_name,
-    get_package_version_from_requirements,
     target_device_is_ovms,
 )
 
 MODEL_DIR_NAME = "model"
 PYTHON_DIR_NAME = "python"
-REQUIREMENTS_FILE_NAME = "requirements.txt"
 
 SALIENCY_KEY = "saliency_map"
 ANOMALY_SALIENCY_KEY = "anomaly_map"
@@ -167,23 +164,6 @@ class DeployedModel(OptimizedModel):
                     )
 
                 self._model_python_path = os.path.join(source, PYTHON_DIR_NAME)
-
-            # A model is being loaded from disk, check if it is a legacy model
-            # We support OTX models starting from version 1.5.0
-            otx_version = get_package_version_from_requirements(
-                requirements_path=os.path.join(
-                    self._model_python_path, REQUIREMENTS_FILE_NAME
-                ),
-                package_name="otx",
-            )
-            if otx_version:  # Empty string if package not found
-                if Version(otx_version) < Version("1.5.0"):
-                    raise ValueError(
-                        "\n"
-                        "This deployment model is not compatible with the current SDK. Proposed solutions:\n"
-                        "1. Please deploy a model using Intel Geti Platform version 2.0.0 or higher.\n"
-                        "2. Downgrade to a compatible Geti-SDK version to continue using this model.\n\n"
-                    )
 
         elif isinstance(source, GetiSession):
             if self.base_url is None:

--- a/geti_sdk/deployment/utils.py
+++ b/geti_sdk/deployment/utils.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-import os
 import re
 from importlib import resources
-from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple
 
 import numpy as np
@@ -116,31 +114,6 @@ def rgb_to_hex(rgb: Tuple[int, int, int]) -> str:
         '#ff0000'
     """
     return "#{:02x}{:02x}{:02x}".format(rgb[0], rgb[1], rgb[2])
-
-
-def get_package_version_from_requirements(
-    requirements_path: os.PathLike, package_name: str
-) -> str:
-    """
-    Get the version of a package from a requirements file.
-
-    :param requirements_path: The requirements file path
-    :param package_name: The name of the package to get the version of
-    :return: The version of the package as a string, empty line if the package is not found.
-    :raises: ValueError If the requirements file is not found.
-    """
-    if not package_name:
-        return ""
-
-    requirements_path = Path(requirements_path).resolve()
-    if not requirements_path.exists():
-        raise ValueError(f"Requirements file {requirements_path} not found")
-
-    for line in requirements_path.read_text().split("\n"):
-        # The OTX package may be installed from a GitHub url
-        if line.startswith(package_name) and "==" in line:
-            return line.split("==")[1].strip()
-    return ""
 
 
 def assign_empty_label(


### PR DESCRIPTION
### Summary

Changes:
- Remove an old assertion that verified if the deployed model was trained before or after OTX 1.5
  - Models trained with very old OTX versions are no longer circulating, so we can safely remove the check
  - The check was somewhat problematic because it makes strong assumptions on the folder structure of the deployment package

### How to test

Install geti-sdk with this branch, run `demo.py` of any code deployment.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​
