### PR TITLE
ci: update Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -128,6 +128,22 @@
       matchDepNames: ["python"],
       matchDepTypes: ["uses-with"],
     },
+
+    // Do not upgrade uv version used in workflows,
+    // it will be updated manually
+    {
+      enabled: false,
+      matchDatasources: ["github-releases"],
+      matchPackageNames: ["astral-sh/uv"],
+    },
+
+    // Do not upgrade ruff to match with pre-commit,
+    // it will be updated manually
+    {
+      enabled: false,
+      matchDatasources: ["pypi"],
+      matchPackageNames: ["ruff"],
+    },
   ],
 
   // Enable security upgrades


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/geti-sdk/blob/main/CONTRIBUTING.md -->

### Summary

Fixes #662, in addition `ruff` upgrade is disabled.

### How to test
Was tested in fork - PR example https://github.com/AlexanderBarabanov/geti-sdk/pull/3/files

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/geti-sdk/blob/main/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
# http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions
# and limitations under the License.
```
