### PR TITLE
bugfix: export DatasetFormat symbol from data_models.enums

### DIFF
--- a/geti_sdk/data_models/enums/__init__.py
+++ b/geti_sdk/data_models/enums/__init__.py
@@ -17,6 +17,7 @@
 from .annotation_kind import AnnotationKind
 from .annotation_state import AnnotationState
 from .configuration_enums import ConfigurationEntityType
+from .dataset_format import DatasetFormat
 from .deployment_state import DeploymentState
 from .domain import Domain
 from .job_state import JobState
@@ -46,4 +47,5 @@ __all__ = [
     "JobState",
     "DeploymentState",
     "SubsetPurpose",
+    "DatasetFormat",
 ]


### PR DESCRIPTION
### Summary

An [example](https://github.com/open-edge-platform/geti-sdk/tree/main?tab=readme-ov-file#importexport) in the README uses the following import:
```python
from geti_sdk.data_models.enums import DatasetFormat
```
The example currently fails because that module doesn't export `DatasetFormat`. This PR fixes it.

### How to test

Install, open a Python shell and run the example.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​