### PR TITLE
loosing version control + update of README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ pip install geti-sdk
 ```
 
 > [!IMPORTANT]
-> Make sure to install a version of the SDK that matches your Geti server version. For example, if you're using Geti server version 2.13, install SDK version 2.13:
+> Make sure to install a version of the SDK that is compatible with your Geti server version. The major and minor versions should match (e.g., SDK 2.13.x is compatible with server 2.13.x), but patch version mismatches are allowed. For example, if you're using Geti server version 2.13, install SDK version 2.13:
 > ```bash
 > pip install geti-sdk==2.13
 > ```
@@ -232,8 +232,7 @@ uploaded_image = image_client.upload_image(image)
 #### Annotate an image
 
 ```python
-from geti_sdk.data_models import Annotation
-from geti_sdk.data_models.shapes import Rectangle
+from geti_sdk.data_models import Annotation, Rectangle
 
 
 # Create a bounding box annotation

--- a/geti_sdk/data_models/__init__.py
+++ b/geti_sdk/data_models/__init__.py
@@ -187,6 +187,7 @@ from .model_group import ModelGroup, ModelSummary
 from .performance import Performance
 from .predictions import Prediction
 from .project import Pipeline, Project
+from .shapes import Ellipse, Keypoint, Point, Polygon, Rectangle, RotatedRectangle
 from .status import ProjectStatus
 from .task import Task
 from .test_result import Score, TestResult
@@ -230,4 +231,10 @@ __all__ = [
     "Subscription",
     "Subset",
     "TrainingDatasetStatistics",
+    "Rectangle",
+    "RotatedRectangle",
+    "Ellipse",
+    "Polygon",
+    "Point",
+    "Keypoint",
 ]

--- a/geti_sdk/geti.py
+++ b/geti_sdk/geti.py
@@ -206,12 +206,13 @@ class Geti:
             Geti™ SDK.
         """
         # Check if the platform version is newer than the SDK version
-        major_platform_version = '.'.join(self.session.version.version.split('.')[:2])
-        major_sdk_version = '.'.join(self.sdk_version.split('.')[:2])
+        major_platform_version = f"{self.session.version.version.major}.{self.session.version.version.minor}"
+        major_sdk_version = f"{self.sdk_version.major}.{self.sdk_version.minor}"
+
         if major_platform_version > major_sdk_version:
             warnings.warn(
                 f"The Geti™ server version {self.session.version.version} is newer than "
-                f"the Geti SDK version {major_sdk_version}. Some features may not be "
+                f"the Geti SDK version {self.sdk_version}. Some features may not be "
                 "supported and you may encounter errors.\n"
                 "Please update the Geti SDK to the latest version "
                 "with `pip install --upgrade geti-sdk`."


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/geti-sdk/blob/main/CONTRIBUTING.md -->

### Summary

Resolves #697 

and additionally relaxes validation of version - now this validation doesn't take into account a patch version

### How to test

Check if connection to Geti version X.Y.1 using Geti SDK version X.Y.0 doesn't display any warning related to incompatibility.

### Checklist

- [x] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​


